### PR TITLE
Add initial codebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      OMP_NUM_THREADS: 4
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: python -m pip install -e ".[dev]"
+      - run: python -m ruff check .
+      - run: python -m pytest src -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Agentic tools
+AGENTS.md
+GEMINI.md
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,23 @@
-## v0.1.0 (2026-07-08)
-
-
+## v0.1.0 (2026-07-10)
 
 ### Added
 
-
-
 - Initial public release of NEST.
 
-- Project structure.
+- `nest.sftda`: Noncollinear spin-flip TDA and TDDFT (SF-TDA/SF-TDDFT) based on
+  unrestricted Kohn–Sham references. Supports collinear (`col`) and multicollinear
+  (`mcol`) exchange–correlation kernels. Registers `TDA_SF` and `TDDFT_SF` methods
+  on PySCF UKS/UHF objects.
 
-- README documentation.
+- `nest.nttda`: Noncollinear Tensor TDA (NT-TDA) based on ROKS references.
+  Supports spin-conserving (ΔS = 0) and spin-flip (ΔS = ±1) excitations free from
+  spin contamination. Registers `NTTDA` on PySCF ROKS objects.
+
+- `nest.grad`: Analytic nuclear gradients for SF-TDA and SF-TDDFT.
+
+- Examples for SF-TDDFT, ROKS SF-TDDFT, NT-TDA, and SF-TDA analytic gradients
+  under `examples/`.
+
+- GitHub Actions CI: lint with ruff and test suite via pytest.
 
 - Apache License 2.0.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,34 @@ NEST is an open-source framework for developing methods based on noncollinear el
     
 ## Installation
 
-...
+From the repository root, install NEST and its runtime dependencies in editable
+mode:
+
+```bash
+python -m pip install -e .
+```
+
+Install the test and lint tools for development:
+
+```bash
+python -m pip install -e ".[dev]"
+```
+
+Importing a feature module registers its methods on the corresponding PySCF
+mean-field objects:
+
+```python
+from pyscf import gto
+from nest import nttda, sftda
+
+mol = gto.M(atom="H 0 0 0; H 0 0 1", spin=2)
+uks = mol.UKS(xc="HF")
+roks = mol.ROKS(xc="HF")
+sf = uks.SFTDA()
+nt = roks.NTTDA()
+```
+
+See [`examples`](examples) for complete calculations.
 
 ## License
 
@@ -62,4 +89,3 @@ If you use NEST in your research, please cite the relevant publication(s) listed
 ### Noncollinear Tensor TDA (NT-TDA)
 
 - Manuscript in preparation.
-

--- a/examples/grad/01_sftda_grad.py
+++ b/examples/grad/01_sftda_grad.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Analytic gradient spin-flip TDDFT/TDA examples.
+'''
+
+import numpy as np
+from pyscf import gto
+from nest import sftda  # necessary import
+
+atom = '''
+H  0.000000  0.934473 -0.588078
+H  0.000000 -0.934473 -0.588078
+C  0.000000  0.000000  0.000000
+O  0.000000  0.000000  1.221104
+'''
+mol = gto.M(atom=atom, charge=0, spin=2, basis='6-31g', verbose=3)
+fun = 'CAM-B3LYP'  # try also 'TPSS', 'SVWN', etc.
+mf = mol.UKS(xc=fun)
+mf.grids.level = 7  # increase grid size for accuracy
+mf.kernel()
+td = mf.SFTDDFT()  # mf.SFTDA() for SF-TDA
+td.extype = 1
+td.collinear_samples = 20  # use collinear='col' for collinear SF-TDDFT
+td.nstates = 5
+td.kernel()
+
+tdg = td.Gradients()
+anal_grad = tdg.kernel(state=1)  # 1 for first excited state
+
+def numerical_gradient(f, mol, delta=1e-5):
+    coords = mol.atom_coords()
+    grad = np.zeros_like(coords)
+    for i in range(mol.natm):
+        for j in range(3):
+            orig_val = coords[i, j]
+            coords[i, j] = orig_val + delta
+            mol.set_geom_(coords, unit='Bohr')
+            f_plus = f(mol)
+            coords[i, j] = orig_val - delta
+            mol.set_geom_(coords, unit='Bohr')
+            f_minus = f(mol)
+            grad[i, j] = (f_plus - f_minus) / (2 * delta)
+            coords[i, j] = orig_val
+    mol.set_geom_(coords, unit='Bohr')
+    return grad
+
+def f(mol):
+    mf = mol.UKS(xc=fun)
+    mf.kernel()
+    td = mf.SFTDDFT()
+    td.extype = 1
+    td.nstates = 5
+    td.collinear_samples = 20
+    td.kernel()
+    return td.e[0] + mf.e_tot
+
+num_grad = numerical_gradient(f, mol)
+
+print("Analytic Gradient:\n", anal_grad)
+print("Numerical Gradient:\n", num_grad)
+print(np.allclose(anal_grad, num_grad, atol=1e-5))

--- a/examples/nttda/01_nttda.py
+++ b/examples/nttda/01_nttda.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run noncollinear tensor TDA from a high-spin ROKS reference."""
+
+from pyscf import gto
+
+from nest import nttda
+
+mol = gto.M(
+    atom="""
+    H  0.000000  0.934473 -0.588078
+    H  0.000000 -0.934473 -0.588078
+    C  0.000000  0.000000  0.000000
+    O  0.000000  0.000000  1.221104
+    """,
+    basis="6-31g",
+    spin=2,
+    symmetry=True,
+)
+mf = mol.ROKS(xc="CAM-B3LYP").run()
+
+td = mf.NTTDA()
+td.deltaS = -1  # Final spin: Sf = Si + deltaS. Valid values are -1, 0, and +1.
+td.nobeta = False
+td.nstates = 5
+td.run().analyze(verbose=4)

--- a/examples/sftda/01_sftddft.py
+++ b/examples/sftda/01_sftddft.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Spin-flip TDDFT/TDA examples.
+
+Key features demonstrated:
+1. Spin-flip down (High spin -> Low spin) setup.
+2. Spin-flip up (High spin -> Higher spin) setup.
+3. Critical parameters: extype, collinear_samples
+4. Validation via explicit construction and diagonalization of the Casida matrix.
+'''
+
+import numpy as np
+from pyscf import gto
+from nest import sftda  # Necessary import (registers methods on UHF/UKS)
+
+def print_header(title):
+    print("\n" + "="*60)
+    print(f" {title}")
+    print("="*60)
+
+# -------------------------------------------------------------------
+# 1. Initialization
+# -------------------------------------------------------------------
+atom = '''
+H  0.000000  0.934473 -0.588078
+H  0.000000 -0.934473 -0.588078
+C  0.000000  0.000000  0.000000
+O  0.000000  0.000000  1.221104
+'''
+# Triplet reference state
+mol = gto.M(atom=atom, basis='6-31G', charge=0, spin=2, symmetry=True)
+mf = mol.UKS(xc='CAM-B3LYP')
+mf.kernel()
+
+print_header("Reference Ground State Analysis")
+mf.analyze()  # Check orbital symmetries of the reference
+
+# -------------------------------------------------------------------
+# 2. Spin-Flip-Down TDDFT (e.g., Triplet -> Singlet)
+# -------------------------------------------------------------------
+print_header("CALCULATION 1: Spin-Flip-Down TDDFT")
+
+sfd_tddft = mf.SFTDDFT()
+sfd_tddft.nstates = 5
+
+# --- Key Settings ---
+# extype=0/1 for spin-flip-up/flip-down excitations
+sfd_tddft.extype = 1  # 1 for spin-flip-down excitations
+
+# collinear_samples: Grid points for multicollinear integration.
+# 20 is a typical robust value. Use collinear='col' for the collinear SF-TDDFT.
+sfd_tddft.collinear_samples = 20
+
+sfd_tddft.kernel()
+sfd_tddft.analyze(verbose=4)  # Verbose=4 shows orbital composition
+
+# -------------------------------------------------------------------
+# 3. Validation: Full Diagonalization of Casida Matrix
+# -------------------------------------------------------------------
+print_header("VALIDATION: Explicit Casida Matrix Diagonalization")
+
+a, b = sftda.uhf_sf.get_ab_sf(mf, collinear_samples=20)
+A_baba, A_abab = a
+B_baab, B_abba = b
+n_occ_a, n_virt_b = A_abab.shape[0], A_abab.shape[1]
+n_occ_b, n_virt_a = B_abba.shape[2], B_abba.shape[3]
+A_abab_2d = A_abab.reshape((n_occ_a*n_virt_b, n_occ_a*n_virt_b), order='C')
+B_abba_2d = B_abba.reshape((n_occ_a*n_virt_b, n_occ_b*n_virt_a), order='C')
+B_baab_2d = B_baab.reshape((n_occ_b*n_virt_a, n_occ_a*n_virt_b), order='C')
+A_baba_2d = A_baba.reshape((n_occ_b*n_virt_a, n_occ_b*n_virt_a), order='C')
+Casida_matrix = np.block([[ A_abab_2d, B_abba_2d],
+                          [-B_baab_2d,-A_baba_2d]])
+eigenvals, eigenvecs = np.linalg.eig(Casida_matrix)
+idx = eigenvals.real.argsort()
+eigenvals = eigenvals[idx]
+eigenvecs = eigenvecs[:, idx]
+norms = np.linalg.norm(eigenvecs[:n_occ_a * n_virt_b], axis=0)**2
+norms -= np.linalg.norm(eigenvecs[n_occ_a * n_virt_b:], axis=0)**2
+sfd_eigenvals = eigenvals[norms > 0]
+sfd_eigenvecs = eigenvecs[:, norms > 0].transpose(1, 0)
+
+def norm_xy(z):
+    x = z[:n_occ_a*n_virt_b].reshape(n_occ_a, n_virt_b)
+    y = z[n_occ_a*n_virt_b:].reshape(n_occ_b, n_virt_a)
+    norm = np.linalg.norm(x)**2 - np.linalg.norm(y)**2
+    norm = np.sqrt(1./norm)
+    return (x*norm, y*norm)
+
+# Create a dummy object
+fake_td = mf.SFTDDFT()
+fake_td.nstates = 5
+fake_td.extype = 1
+fake_td.collinear_samples = 20
+fake_td.e = sfd_eigenvals
+fake_td.xy = [norm_xy(z) for z in sfd_eigenvecs]
+fake_td.analyze()
+
+# -------------------------------------------------------------------
+# 4. Spin-Flip-Down TDA
+# -------------------------------------------------------------------
+print_header("CALCULATION 2: Spin-Flip-Down TDA")
+
+sfd_tda = mf.SFTDA()
+sfd_tda.extype = 1
+sfd_tda.nstates = 5
+sfd_tda.collinear = 'col'  # Use collinear functional
+sfd_tda.kernel()
+sfd_tda.analyze()
+
+# -------------------------------------------------------------------
+# 5. Spin-Flip-Up TDDFT (e.g. Triplet -> Quintet)
+# -------------------------------------------------------------------
+print_header("CALCULATION 3: Spin-Flip-Up TDDFT")
+
+sfu_tddft = sftda.SFTDDFT(mf)
+sfu_tddft.extype = 0  # 0 for spin-flip-up excitations
+sfu_tddft.nstates = 5
+sfu_tddft.collinear_samples = 20
+sfu_tddft.kernel()
+sfu_tddft.analyze(verbose=4)
+
+print("\n--- Compare with Casida Neg-Norm Roots ---")
+# Spin-flip-up roots appear as negative eigenvalues in the full Casida matrix
+sfu_evals_val = eigenvals[norms < 0]
+print(f"Casida derived Spin-flip-up Energies (eV): \n{-sfu_evals_val[-5:][::-1] * 27.2114}")

--- a/examples/sftda/02_sftddft_roks.py
+++ b/examples/sftda/02_sftddft_roks.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Spin-flip TDDFT/TDA examples with ROKS reference.
+
+nest.sftda.SFTDDFT/SFTDA can also be applied to ROKS objects,
+or equivalently to mf.to_uks() objects with methods.
+'''
+
+import numpy as np
+from pyscf import gto
+from nest import sftda
+
+def print_header(title):
+    print("\n" + "="*60)
+    print(f" {title}")
+    print("="*60)
+
+atom = '''
+H  0.000000  0.934473 -0.588078
+H  0.000000 -0.934473 -0.588078
+C  0.000000  0.000000  0.000000
+O  0.000000  0.000000  1.221104
+'''
+# Triplet reference state
+mol = gto.M(atom=atom, basis='6-31G', charge=0, spin=2, symmetry=True)
+mf = mol.ROKS(xc='CAM-B3LYP')
+mf.kernel()
+mf.analyze()
+
+# Spin-flip down TDDFT
+print_header("CALCULATION 1: Spin-Flip-Down TDDFT")
+sfd_tddft = sftda.SFTDDFT(mf)  # same as mf.to_uks().SFTDDFT()
+sfd_tddft.nstates = 5
+sfd_tddft.extype = 1  # 1 for spin-flip-down excitations
+sfd_tddft.collinear_samples = 20
+sfd_tddft.kernel()
+sfd_tddft.analyze(verbose=4)
+
+print_header("VALIDATION: Explicit Casida Matrix Diagonalization")
+a, b = sftda.uhf_sf.get_ab_sf(mf, collinear_samples=20)
+A_baba, A_abab = a
+B_baab, B_abba = b
+n_occ_a, n_virt_b = A_abab.shape[0], A_abab.shape[1]
+n_occ_b, n_virt_a = B_abba.shape[2], B_abba.shape[3]
+A_abab_2d = A_abab.reshape((n_occ_a*n_virt_b, n_occ_a*n_virt_b), order='C')
+B_abba_2d = B_abba.reshape((n_occ_a*n_virt_b, n_occ_b*n_virt_a), order='C')
+B_baab_2d = B_baab.reshape((n_occ_b*n_virt_a, n_occ_a*n_virt_b), order='C')
+A_baba_2d = A_baba.reshape((n_occ_b*n_virt_a, n_occ_b*n_virt_a), order='C')
+Casida_matrix = np.block([[ A_abab_2d, B_abba_2d],
+                          [-B_baab_2d,-A_baba_2d]])
+eigenvals, eigenvecs = np.linalg.eig(Casida_matrix)
+idx = eigenvals.real.argsort()
+eigenvals = eigenvals[idx]
+eigenvecs = eigenvecs[:, idx]
+norms = np.linalg.norm(eigenvecs[:n_occ_a * n_virt_b], axis=0)**2
+norms -= np.linalg.norm(eigenvecs[n_occ_a * n_virt_b:], axis=0)**2
+sfd_eigenvals = eigenvals[norms > 0]
+sfd_eigenvecs = eigenvecs[:, norms > 0].transpose(1, 0)
+
+def norm_xy(z):
+    x = z[:n_occ_a*n_virt_b].reshape(n_occ_a, n_virt_b)
+    y = z[n_occ_a*n_virt_b:].reshape(n_occ_b, n_virt_a)
+    norm = np.linalg.norm(x)**2 - np.linalg.norm(y)**2
+    norm = np.sqrt(1./norm)
+    return (x*norm, y*norm)
+
+# Create a dummy object
+fake_td = sftda.SFTDDFT(mf)
+fake_td.nstates = 5
+fake_td.extype = 1
+fake_td.collinear_samples = 20
+fake_td.e = sfd_eigenvals
+fake_td.xy = [norm_xy(z) for z in sfd_eigenvecs]
+fake_td.analyze()
+
+# Spin-flip down TDA
+print_header("CALCULATION 2: Spin-Flip-Down TDA")
+sfd_tda = sftda.SFTDA(mf)  # same as mf.to_uks().SFTDA()
+sfd_tda.extype = 1
+sfd_tda.nstates = 5
+sfd_tda.collinear = 'col'  # Use collinear functional
+sfd_tda.kernel()
+sfd_tda.analyze()
+
+# Spin-flip-up TDA
+print_header("CALCULATION 3: Spin-Flip-Up TDA")
+sfu_tda = sftda.SFTDA(mf)
+sfu_tda.extype = 0  # 0 for spin-flip-up excitations
+sfu_tda.nstates = 5
+sfu_tda.collinear_samples = 20
+sfu_tda.kernel()
+sfu_tda.analyze(verbose=4)

--- a/examples/sftda/03_spin_square_and_fosc.py
+++ b/examples/sftda/03_spin_square_and_fosc.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Expectation value of <S^2> and oscillator strengths between
+excited states using spin-flip TDDFT/TDA.
+"""
+
+import numpy as np
+from pyscf import gto
+from nest import sftda  # Necessary import (registers methods on UHF/UKS)
+
+atom = '''
+ C                 -0.31474382    0.01213719   -0.02117853
+ N                  0.19004517   -1.31047912    0.37476865
+ O                  0.15651526    0.99794522    0.90131667
+ H                 -0.13695077   -1.53063275    1.29379315
+ H                 -0.13950663   -1.99985536   -0.27033289
+ H                 -1.38468136    0.00166093   -0.01628742
+ F                  0.12670070    0.30934460   -1.26186161
+ H                 -0.17314286    1.86169465    0.64273892
+'''
+mol = gto.M(atom=atom, charge=0, spin=2, basis='6-31G*')
+
+mf = mol.UKS(xc='B3LYP').run()
+td = mf.SFTDDFT()
+td.extype = 1
+td.collinear_samples = 20
+td.nstates = 5
+td.kernel()
+td.analyze()
+
+# 1. Spin Purity (S^2)
+# The <S^2> value helps identify the spin multiplicity of the excited states.
+print(td.spin_square(state=[1, 2, 3]))  # state=[1, 2, 3] for the 1st, 2nd, and 3rd excited states
+
+# 2. Oscillator Strengths between Excited States
+# ref:   The "starting" state (Reference state).
+#        Here ref=1 refers to the first excited state.
+# state: The "target" states.
+#        state=[2, 3] means we calculate transitions: 1 -> 2 and 1 -> 3.
+print(td.oscillator_strength(ref=1, state=[2, 3]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,58 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nest"
+version = "0.1.0"
+description = "NEST: Noncollinear Electronic Structure Theory"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+dependencies = [
+    "mcfun>=0.2.6",
+    "pyscf>=2.13.0",
+    "numpy",
+    "scipy",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "ruff",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+exclude = [
+    "tests",
+    "examples",
+]
+
+[tool.ruff.lint]
+select = [
+    "E4",
+    "E7",
+    "E9",
+    "F",
+    "W191",
+    "W291",
+    "W293",
+]
+ignore = [
+    "E402",
+    "E741",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+
+[tool.ruff.format]
+quote-style = "single"
+indent-style = "space"
+line-ending = "auto"

--- a/src/nest/__init__.py
+++ b/src/nest/__init__.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""nest package."""
+
+from nest import nttda, sftda
+
+__version__ = "0.1.0"
+
+__all__ = ["__version__", "nttda", "sftda"]

--- a/src/nest/grad/__init__.py
+++ b/src/nest/grad/__init__.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gradient methods for NEST."""
+
+__all__ = []

--- a/src/nest/grad/tduks_sf.py
+++ b/src/nest/grad/tduks_sf.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python
+# Copyright 2014-2024 The PySCF Developers. All Rights Reserved.
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Ref:
+# J. Chem. Theory Comput. 2025, 21, 6, 3010
+#
+
+from functools import reduce
+import numpy as np
+from pyscf import lib
+from pyscf.lib import logger
+from pyscf.scf import ucphf
+from pyscf.dft import numint2c
+from pyscf.grad import tdrhf as tdrhf_grad
+from pyscf.grad import tdrks as tdrks_grad
+from pyscf.grad import tduks as tduks_grad
+from nest.sftda.numint2c_sftd import mcfun_eval_xc_adapter_sf
+
+
+def grad_elec(td_grad, x_y, atmlst=None, max_memory=2000, verbose=logger.INFO):
+    """
+    Electronic part of spin-flip TDA/TDDFT nuclear gradients.
+
+    Args:
+        td_grad : grad.tduks_sf.Gradients object.
+
+        x_y : a two-element list of numpy arrays
+            TDDFT X and Y amplitudes. If Y is set to 0, this function computes
+            TDA energy gradients.
+    """
+    log = logger.new_logger(td_grad, verbose)
+    time0 = logger.process_clock(), logger.perf_counter()
+
+    mol = td_grad.mol
+    mf = td_grad.base._scf
+
+    mo_coeff = mf.mo_coeff
+    mo_energy = mf.mo_energy
+    mo_occ = mf.mo_occ
+    occidxa = np.where(mo_occ[0] > 0)[0]
+    occidxb = np.where(mo_occ[1] > 0)[0]
+    viridxa = np.where(mo_occ[0] == 0)[0]
+    viridxb = np.where(mo_occ[1] == 0)[0]
+    nocca = len(occidxa)
+    noccb = len(occidxb)
+    nvira = len(viridxa)
+    nvirb = len(viridxb)
+    orboa = mo_coeff[0][:, occidxa]
+    orbob = mo_coeff[1][:, occidxb]
+    orbva = mo_coeff[0][:, viridxa]
+    orbvb = mo_coeff[1][:, viridxb]
+    nao = mo_coeff[0].shape[0]
+    nmoa = nocca + nvira
+    nmob = noccb + nvirb
+
+    if td_grad.base.extype == 0:
+        y, x = x_y
+        if not isinstance(x, np.ndarray):
+            x = np.zeros((nocca, nvirb))
+    elif td_grad.base.extype == 1:
+        x, y = x_y
+        if not isinstance(y, np.ndarray):
+            y = np.zeros((noccb, nvira))
+
+    dvva = lib.einsum('ia,ib->ab', y, y)
+    dvvb = lib.einsum('ia,ib->ab', x, x)
+    dooa = -lib.einsum('ia,ja->ij', x, x)
+    doob = -lib.einsum('ia,ja->ij', y, y)
+
+    dmzooa = reduce(np.dot, (orboa, dooa, orboa.T))
+    dmzooa += reduce(np.dot, (orbva, dvva, orbva.T))
+    dmzoob = reduce(np.dot, (orbob, doob, orbob.T))
+    dmzoob += reduce(np.dot, (orbvb, dvvb, orbvb.T))
+
+    dmx = reduce(np.dot, (orbvb, x.T, orboa.T))  # ba
+    dmy = reduce(np.dot, (orbob, y, orbva.T))  # ba
+    dmt = dmx + dmy
+
+    ni = mf._numint
+    ni.libxc.test_deriv_order(mf.xc, 3, raise_error=True)
+    omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
+
+    f1vo, f1oo, vxc1, k1ao = _contract_xc_kernel(td_grad, mf.xc, dmt, (dmzooa, dmzoob), True, True, max_memory)
+
+    with_k = ni.libxc.is_hybrid_xc(mf.xc)
+    if with_k:
+        vj0, vk0 = mf.get_jk(mol, (dmzooa, dmzoob), hermi=1)  # (2, nao, nao)
+        vk1 = mf.get_k(mol, dmt, hermi=0) * hyb  # (nao, nao)
+        vk0 = vk0 * hyb
+        if omega != 0:
+            vk0 += mf.get_k(mol, (dmzooa, dmzoob), hermi=1, omega=omega) * (alpha - hyb)
+            vk1 += mf.get_k(mol, dmt, hermi=0, omega=omega) * (alpha - hyb)
+
+        veff0doo = vj0[0] + vj0[1] - vk0 + f1oo[:, 0] + k1ao[:, 0]
+        wvoa = reduce(np.dot, (orbva.T, veff0doo[0], orboa))
+        wvob = reduce(np.dot, (orbvb.T, veff0doo[1], orbob))
+
+        veff0mo = reduce(np.dot, (mo_coeff[1].T, f1vo[0] - vk1, mo_coeff[0]))
+        wvoa += lib.einsum('ac,ka->ck', veff0mo[noccb:, nocca:], x)
+        wvoa -= lib.einsum('jk,jc->ck', veff0mo[:noccb, :nocca], y)
+        wvob += lib.einsum('ac,ka->ck', veff0mo.T[nocca:, noccb:], y)
+        wvob -= lib.einsum('jk,jc->ck', veff0mo.T[:nocca, :noccb], x)
+
+    else:
+        vj0 = mf.get_j(mol, (dmzooa, dmzoob), hermi=1)  # (2, nao, nao)
+        veff0doo = vj0[0] + vj0[1] + f1oo[:, 0] + k1ao[:, 0]
+        wvoa = reduce(np.dot, (orbva.T, veff0doo[0], orboa))
+        wvob = reduce(np.dot, (orbvb.T, veff0doo[1], orbob))
+
+        veff0mo = reduce(np.dot, (mo_coeff[1].T, f1vo[0], mo_coeff[0]))
+        wvoa += lib.einsum('ac,ka->ck', veff0mo[noccb:, nocca:], x)
+        wvoa -= lib.einsum('jk,jc->ck', veff0mo[:noccb, :nocca], y)
+        wvob += lib.einsum('ac,ka->ck', veff0mo.T[nocca:, noccb:], y)
+        wvob -= lib.einsum('jk,jc->ck', veff0mo.T[:nocca, :noccb], x)
+
+    vresp = mf.gen_response(hermi=1)
+
+    def fvind(x):
+        xa = x[0, : nvira * nocca].reshape(nvira, nocca)
+        xb = x[0, nvira * nocca :].reshape(nvirb, noccb)
+        dma = reduce(np.dot, (orbva, xa, orboa.T))
+        dmb = reduce(np.dot, (orbvb, xb, orbob.T))
+        dm1 = np.stack((dma + dma.T, dmb + dmb.T))
+        v1 = vresp(dm1)
+        v1a = reduce(np.dot, (orbva.T, v1[0], orboa))
+        v1b = reduce(np.dot, (orbvb.T, v1[1], orbob))
+        return np.hstack((v1a.ravel(), v1b.ravel()))
+
+    z1a, z1b = ucphf.solve(
+        fvind, mo_energy, mo_occ, (wvoa, wvob), max_cycle=td_grad.cphf_max_cycle, tol=td_grad.cphf_conv_tol
+    )[0]
+    time1 = log.timer('Z-vector using UCPHF solver', *time0)
+
+    z1ao = np.empty((2, nao, nao))
+    z1ao[0] = reduce(np.dot, (orbva, z1a, orboa.T))
+    z1ao[1] = reduce(np.dot, (orbvb, z1b, orbob.T))
+    veff = vresp((z1ao + z1ao.transpose(0, 2, 1)))
+
+    im0a = np.zeros((nmoa, nmoa))
+    im0b = np.zeros((nmob, nmob))
+    im0a[:nocca, :nocca] = reduce(np.dot, (orboa.T, veff0doo[0] + veff[0], orboa))
+    im0b[:noccb, :noccb] = reduce(np.dot, (orbob.T, veff0doo[1] + veff[1], orbob))
+    im0a[:nocca, :nocca] += lib.einsum('al,ka->lk', veff0mo[noccb:, :nocca], x)
+    im0b[:noccb, :noccb] += lib.einsum('al,ka->lk', veff0mo.T[nocca:, :noccb], y)
+    im0a[nocca:, nocca:] = lib.einsum('jd,jc->dc', veff0mo[:noccb, nocca:], y)
+    im0b[noccb:, noccb:] = lib.einsum('jd,jc->dc', veff0mo.T[:nocca, noccb:], x)
+    im0a[:nocca, nocca:] = lib.einsum('jk,jc->kc', veff0mo[:noccb, :nocca], y) * 2
+    im0b[:noccb, noccb:] = lib.einsum('jk,jc->kc', veff0mo.T[:nocca, :noccb], x) * 2
+
+    zeta_a = (mo_energy[0][:, None] + mo_energy[0]) * 0.5
+    zeta_b = (mo_energy[1][:, None] + mo_energy[1]) * 0.5
+    zeta_a[nocca:, :nocca] = mo_energy[0][:nocca]
+    zeta_b[noccb:, :noccb] = mo_energy[1][:noccb]
+    zeta_a[:nocca, nocca:] = mo_energy[0][nocca:]
+    zeta_b[:noccb, noccb:] = mo_energy[1][noccb:]
+    dm1a = np.zeros((nmoa, nmoa))
+    dm1b = np.zeros((nmob, nmob))
+    dm1a[:nocca, :nocca] = dooa
+    dm1b[:noccb, :noccb] = doob
+    dm1a[nocca:, nocca:] = dvva
+    dm1b[noccb:, noccb:] = dvvb
+    dm1a[nocca:, :nocca] = z1a * 2
+    dm1b[noccb:, :noccb] = z1b * 2
+    dm1a[:nocca, :nocca] += np.eye(nocca)  # for ground state
+    dm1b[:noccb, :noccb] += np.eye(noccb)
+    im0a = reduce(np.dot, (mo_coeff[0], im0a + zeta_a * dm1a, mo_coeff[0].T))
+    im0b = reduce(np.dot, (mo_coeff[1], im0b + zeta_b * dm1b, mo_coeff[1].T))
+    im0 = im0a + im0b
+
+    mf_grad = td_grad.base._scf.nuc_grad_method()
+    hcore_deriv = mf_grad.hcore_generator(mol)
+    s1 = mf_grad.get_ovlp(mol)
+
+    dmz1dooa = 4 * z1ao[0] + 2 * dmzooa
+    dmz1doob = 4 * z1ao[1] + 2 * dmzoob
+    oo0a = reduce(np.dot, (orboa, orboa.T))
+    oo0b = reduce(np.dot, (orbob, orbob.T))
+    as_dm1 = oo0a + oo0b + (dmz1dooa + dmz1doob) * 0.5
+
+    if with_k:
+        dm = (oo0a, dmz1dooa + dmz1dooa.T, oo0b, dmz1doob + dmz1doob.T)
+        vj, vk = td_grad.get_jk(mol, dm, hermi=1)
+        vj = vj.reshape(2, 2, 3, nao, nao)
+        vk = vk.reshape(2, 2, 3, nao, nao) * hyb
+        vk1 = -td_grad.get_k(mol, (dmt, dmt.T)) * hyb
+        if omega != 0:
+            vk += td_grad.get_k(mol, dm, omega=omega).reshape(2, 2, 3, nao, nao) * (alpha - hyb)
+            vk1 += -td_grad.get_k(mol, (dmt, dmt.T), omega=omega) * (alpha - hyb)
+        veff1 = vj[0] + vj[1] - vk
+    else:
+        dm = (oo0a, dmz1dooa + dmz1dooa.T, oo0b, dmz1doob + dmz1doob.T)
+        vj = td_grad.get_j(mol, dm, hermi=1).reshape(2, 2, 3, nao, nao)
+        veff1 = vj[0] + vj[1]
+        veff1 = np.stack((veff1, veff1))
+
+    fxcz1 = tduks_grad._contract_xc_kernel(td_grad, mf.xc, 2 * z1ao, None, False, False, max_memory)[0]
+    veff1[:, 0] += vxc1[:, 1:]
+    veff1[:, 1] += (f1oo[:, 1:] + fxcz1[:, 1:] + k1ao[:, 1:]) * 4
+    veff1a, veff1b = veff1
+    time1 = log.timer('2e AO integral derivatives', *time1)
+
+    if atmlst is None:
+        atmlst = range(mol.natm)
+    offsetdic = mol.offset_nr_by_atom()
+    de = np.zeros((len(atmlst), 3))
+
+    for k, ia in enumerate(atmlst):
+        shl0, shl1, p0, p1 = offsetdic[ia]
+
+        # Ground state gradients
+        h1ao = hcore_deriv(ia)
+        de[k] = lib.einsum('xpq,pq->x', h1ao, as_dm1)
+        de[k] += lib.einsum('xpq,pq->x', veff1a[0, :, p0:p1], oo0a[p0:p1]) * 2
+        de[k] += lib.einsum('xpq,pq->x', veff1b[0, :, p0:p1], oo0b[p0:p1]) * 2
+
+        # Excitation energy gradients
+        de[k] -= lib.einsum('xpq,pq->x', s1[:, p0:p1], im0[p0:p1])
+        de[k] -= lib.einsum('xqp,pq->x', s1[:, p0:p1], im0[:, p0:p1])
+
+        de[k] += lib.einsum('xpq,pq->x', veff1a[0, :, p0:p1], dmz1dooa[p0:p1]) * 0.5
+        de[k] += lib.einsum('xpq,pq->x', veff1b[0, :, p0:p1], dmz1doob[p0:p1]) * 0.5
+        de[k] += lib.einsum('xpq,qp->x', veff1a[0, :, p0:p1], dmz1dooa[:, p0:p1]) * 0.5
+        de[k] += lib.einsum('xpq,qp->x', veff1b[0, :, p0:p1], dmz1doob[:, p0:p1]) * 0.5
+        de[k] += lib.einsum('xij,ij->x', veff1a[1, :, p0:p1], oo0a[p0:p1]) * 0.5
+        de[k] += lib.einsum('xij,ij->x', veff1b[1, :, p0:p1], oo0b[p0:p1]) * 0.5
+
+        if td_grad.base.collinear == "mcol":
+            de[k] += lib.einsum('xpq,pq->x', f1vo[1:, p0:p1], dmt[p0:p1]) * 2
+            de[k] += lib.einsum('xpq,pq->x', f1vo[1:, p0:p1], dmt.T[p0:p1]) * 2
+
+        if with_k:
+            de[k] += lib.einsum('xpq,pq->x', vk1[0, :, p0:p1], dmt[p0:p1]) * 2
+            de[k] += lib.einsum('xpq,pq->x', vk1[1, :, p0:p1], dmt.T[p0:p1]) * 2
+
+        de[k] += td_grad.extra_force(ia, locals())
+
+    log.timer('TDUKS nuclear gradients', *time0)
+    return de
+
+
+def _contract_xc_kernel(td_grad, xc_code, dmvo, dmoo=None, with_vxc=True, with_kxc=True, max_memory=2000):
+    mol = td_grad.mol
+    mf = td_grad.base._scf
+    grids = mf.grids
+
+    ni = mf._numint
+    xctype = ni._xc_type(xc_code)
+
+    mo_coeff = mf.mo_coeff
+    mo_occ = mf.mo_occ
+    nao = mo_coeff[0].shape[0]
+    shls_slice = (0, mol.nbas)
+    ao_loc = mol.ao_loc_nr()
+
+    dmvo = (dmvo + dmvo.T) * 0.5
+
+    f1vo = np.zeros((4, nao, nao))
+    deriv = 2
+    if dmoo is not None:
+        f1oo = np.zeros((2, 4, nao, nao))
+    else:
+        f1oo = None
+    if with_vxc:
+        v1ao = np.zeros((2, 4, nao, nao))
+    else:
+        v1ao = None
+    if with_kxc:
+        k1ao = np.zeros((2, 4, nao, nao))
+        deriv = 3
+    else:
+        k1ao = None
+
+    if td_grad.base.collinear == "mcol":
+        # create a mc object to use mcfun.
+        nimc = numint2c.NumInt2C()
+        nimc.collinear = "mcol"
+        nimc.collinear_samples = td_grad.base.collinear_samples
+        eval_xc_eff = mcfun_eval_xc_adapter_sf(nimc, xc_code)
+
+    if xctype == 'HF':
+        return f1vo, f1oo, v1ao, k1ao
+    elif xctype == 'LDA':
+        fmat_, ao_deriv = tdrks_grad._lda_eval_mat_, 1
+    elif xctype == 'GGA':
+        fmat_, ao_deriv = tdrks_grad._gga_eval_mat_, 2
+    elif xctype == 'MGGA':
+        fmat_, ao_deriv = tdrks_grad._mgga_eval_mat_, 2
+        logger.warn(td_grad, 'TDUKS-MGGA Gradients may be inaccurate due to grids response')
+    else:
+        raise NotImplementedError(f'td-uks for functional {xc_code}')
+
+    for ao, mask, weight, coords in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
+        if xctype == 'LDA':
+            ao0 = ao[0]
+        else:
+            ao0 = ao
+        rho = (
+            ni.eval_rho2(mol, ao0, mo_coeff[0], mo_occ[0], mask, xctype, with_lapl=False),
+            ni.eval_rho2(mol, ao0, mo_coeff[1], mo_occ[1], mask, xctype, with_lapl=False),
+        )
+        if td_grad.base.collinear == "mcol":
+            rho_z = np.array([rho[0] + rho[1], rho[0] - rho[1]])
+            fxc_sf, kxc_sf = eval_xc_eff(xc_code, rho_z, deriv, xctype=xctype)[2:4]
+            kxc_sf = np.stack((kxc_sf[:, :, 0] + kxc_sf[:, :, 1], kxc_sf[:, :, 0] - kxc_sf[:, :, 1]), axis=2)
+            rho1 = ni.eval_rho(mol, ao0, dmvo, mask, xctype, hermi=1, with_lapl=False)
+            if xctype == 'LDA':
+                rho1 = rho1[np.newaxis]
+            wv = lib.einsum('yg,xyg,g->xg', rho1, 2 * fxc_sf, weight)  # 2 for f_xx + f_yy
+            fmat_(mol, f1vo, ao, wv, mask, shls_slice, ao_loc)
+
+            if with_kxc:
+                wv = lib.einsum('xg,yg,xyczg,g->czg', rho1, rho1, 2 * kxc_sf, weight)
+                fmat_(mol, k1ao[0], ao, wv[0], mask, shls_slice, ao_loc)
+                fmat_(mol, k1ao[1], ao, wv[1], mask, shls_slice, ao_loc)
+
+        if dmoo is not None or with_vxc:
+            vxc, fxc, kxc = ni.eval_xc_eff(xc_code, rho, deriv=2, spin=1)[1:]
+
+        if dmoo is not None:
+            rho2 = np.asarray(
+                (
+                    ni.eval_rho(mol, ao0, dmoo[0], mask, xctype, hermi=1, with_lapl=False),
+                    ni.eval_rho(mol, ao0, dmoo[1], mask, xctype, hermi=1, with_lapl=False),
+                )
+            )
+            if xctype == 'LDA':
+                rho2 = rho2[:, np.newaxis]
+            wv = lib.einsum('axg,axbyg,g->byg', rho2, fxc, weight)
+            fmat_(mol, f1oo[0], ao, wv[0], mask, shls_slice, ao_loc)
+            fmat_(mol, f1oo[1], ao, wv[1], mask, shls_slice, ao_loc)
+
+        if with_vxc:
+            wv = vxc * weight
+            fmat_(mol, v1ao[0], ao, wv[0], mask, shls_slice, ao_loc)
+            fmat_(mol, v1ao[1], ao, wv[1], mask, shls_slice, ao_loc)
+
+    f1vo[1:] *= -1
+    if f1oo is not None:
+        f1oo[:, 1:] *= -1
+    if v1ao is not None:
+        v1ao[:, 1:] *= -1
+    if k1ao is not None:
+        k1ao[:, 1:] *= -1
+    return f1vo, f1oo, v1ao, k1ao
+
+
+class Gradients(tdrhf_grad.Gradients):
+    cphf_max_cycle = tdrhf_grad.Gradients.cphf_max_cycle + 20
+
+    @lib.with_doc(grad_elec.__doc__)
+    def grad_elec(self, xy, singlet=None, atmlst=None):
+        return grad_elec(self, xy, atmlst, self.max_memory, self.verbose)
+
+Grad = Gradients

--- a/src/nest/grad/tests/test_tduks_sf_grad.py
+++ b/src/nest/grad/tests/test_tduks_sf_grad.py
@@ -1,0 +1,239 @@
+# Copyright 2021-2024 The PySCF Developers. All Rights Reserved.
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from pyscf import gto
+from nest import sftda
+
+
+def cal_exact_sf_tda_gradient(mf, extype=1, collinear='mcol', collinear_samples=20, state=1):
+    a, b = sftda.uhf_sf.get_ab_sf(mf, collinear=collinear, collinear_samples=collinear_samples)
+    A_baba, A_abab = a
+    B_baab, B_abba = b
+
+    n_occ_a, n_virt_b = A_abab.shape[0], A_abab.shape[1]
+    n_occ_b, n_virt_a = B_abba.shape[2], B_abba.shape[3]
+
+    A_abab_2d = A_abab.reshape((n_occ_a * n_virt_b, n_occ_a * n_virt_b), order='C')
+    B_abba_2d = B_abba.reshape((n_occ_a * n_virt_b, n_occ_b * n_virt_a), order='C')
+    B_baab_2d = B_baab.reshape((n_occ_b * n_virt_a, n_occ_a * n_virt_b), order='C')
+    A_baba_2d = A_baba.reshape((n_occ_b * n_virt_a, n_occ_b * n_virt_a), order='C')
+
+    Casida_matrix = np.block([[A_abab_2d, np.zeros_like(B_abba_2d)], [-np.zeros_like(B_baab_2d), -A_baba_2d]])
+
+    eigenvals, eigenvecs = np.linalg.eig(Casida_matrix)
+    idx = eigenvals.real.argsort()
+    eigenvals = eigenvals[idx]
+    eigenvecs = eigenvecs[:, idx]
+
+    norms = np.linalg.norm(eigenvecs[: n_occ_a * n_virt_b], axis=0) ** 2
+    norms -= np.linalg.norm(eigenvecs[n_occ_a * n_virt_b :], axis=0) ** 2
+
+    if extype == 1:
+        mask = norms > 1e-3
+        valid_e = eigenvals[mask].real
+        eigenvecs = eigenvecs[:, mask].transpose(1, 0)
+
+        def norm_xy(z):
+            x = z[: n_occ_a * n_virt_b].reshape(n_occ_a, n_virt_b)
+            y = z[n_occ_a * n_virt_b :].reshape(n_occ_b, n_virt_a)
+            norm = np.linalg.norm(x) ** 2 - np.linalg.norm(y) ** 2
+            norm = np.sqrt(1.0 / norm)
+            return (x * norm, 0)
+    else:
+        mask = norms < -1e-3
+        valid_e = -eigenvals[mask].real
+        valid_e = valid_e[::-1]
+        eigenvecs = eigenvecs[:, mask][:, ::-1].transpose(1, 0)
+
+        def norm_xy(z):
+            x = z[n_occ_a * n_virt_b :].reshape(n_occ_b, n_virt_a)
+            y = z[: n_occ_a * n_virt_b].reshape(n_occ_a, n_virt_b)
+            norm = np.linalg.norm(x) ** 2 - np.linalg.norm(y) ** 2
+            norm = np.sqrt(1.0 / norm)
+            return (x * norm, 0)
+
+    fake_td = mf.SFTDA()
+    fake_td.collinear = collinear
+    fake_td.collinear_samples = collinear_samples
+    fake_td.extype = extype
+    fake_td.e = valid_e
+    fake_td.xy = [norm_xy(z) for z in eigenvecs]
+    return fake_td.Gradients().kernel(state=state)
+
+
+def cal_exact_sf_tddft_gradient(mf, extype=1, collinear='mcol', collinear_samples=20, state=1):
+    a, b = sftda.uhf_sf.get_ab_sf(mf, collinear=collinear, collinear_samples=collinear_samples)
+    A_baba, A_abab = a
+    B_baab, B_abba = b
+
+    n_occ_a, n_virt_b = A_abab.shape[0], A_abab.shape[1]
+    n_occ_b, n_virt_a = B_abba.shape[2], B_abba.shape[3]
+
+    A_abab_2d = A_abab.reshape((n_occ_a * n_virt_b, n_occ_a * n_virt_b), order='C')
+    B_abba_2d = B_abba.reshape((n_occ_a * n_virt_b, n_occ_b * n_virt_a), order='C')
+    B_baab_2d = B_baab.reshape((n_occ_b * n_virt_a, n_occ_a * n_virt_b), order='C')
+    A_baba_2d = A_baba.reshape((n_occ_b * n_virt_a, n_occ_b * n_virt_a), order='C')
+
+    Casida_matrix = np.block([[A_abab_2d, B_abba_2d], [-B_baab_2d, -A_baba_2d]])
+
+    eigenvals, eigenvecs = np.linalg.eig(Casida_matrix)
+    idx = eigenvals.real.argsort()
+    eigenvals = eigenvals[idx]
+    eigenvecs = eigenvecs[:, idx]
+
+    norms = np.linalg.norm(eigenvecs[: n_occ_a * n_virt_b], axis=0) ** 2
+    norms -= np.linalg.norm(eigenvecs[n_occ_a * n_virt_b :], axis=0) ** 2
+
+    if extype == 1:
+        mask = norms > 1e-3
+        valid_e = eigenvals[mask].real
+        eigenvecs = eigenvecs[:, mask].transpose(1, 0)
+
+        def norm_xy(z):
+            x = z[: n_occ_a * n_virt_b].reshape(n_occ_a, n_virt_b)
+            y = z[n_occ_a * n_virt_b :].reshape(n_occ_b, n_virt_a)
+            norm = np.linalg.norm(x) ** 2 - np.linalg.norm(y) ** 2
+            norm = np.sqrt(1.0 / norm)
+            return (x * norm, y * norm)
+    else:
+        mask = norms < -1e-3
+        valid_e = -eigenvals[mask].real
+        valid_e = valid_e[::-1]
+        eigenvecs = eigenvecs[:, mask][:, ::-1].transpose(1, 0)
+
+        def norm_xy(z):
+            x = z[n_occ_a * n_virt_b :].reshape(n_occ_b, n_virt_a)
+            y = z[: n_occ_a * n_virt_b].reshape(n_occ_a, n_virt_b)
+            norm = np.linalg.norm(x) ** 2 - np.linalg.norm(y) ** 2
+            norm = np.sqrt(1.0 / norm)
+            return (x * norm, y * norm)
+
+    fake_td = mf.SFTDDFT()
+    fake_td.collinear = collinear
+    fake_td.collinear_samples = collinear_samples
+    fake_td.extype = extype
+    fake_td.e = valid_e
+    fake_td.xy = [norm_xy(z) for z in eigenvecs]
+    return fake_td.Gradients().kernel(state=state)
+
+
+class KnownValues(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        mol = gto.Mole()
+        mol.verbose = 0
+        mol.output = '/dev/null'
+        mol.atom = """
+        O     0.   0.       0.
+        H     0.   -0.757   0.587
+        H     0.   0.757    0.587"""
+        mol.spin = 2
+        mol.basis = '631g'
+        cls.mol = mol.build()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mol.stdout.close()
+
+    def test_mcol_lda(self):
+        mf = self.mol.UKS(xc='SVWN').run()
+        td = mf.SFTDA().set(extype=0, collinear='mcol', collinear_samples=20).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=0, collinear='mcol', collinear_samples=20, state=1)
+        ref = np.array(
+            [
+                [-1.1347069729e-16, -1.1084528691e-14, 2.8558017754e-01],
+                [-1.1092137160e-16, 2.7449714063e-01, -1.4279559143e-01],
+                [5.9671903444e-17, -2.7449714063e-01, -1.4279559143e-01],
+            ]
+        )
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, delta=1e-5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, delta=1e-5)
+
+        td = mf.SFTDDFT().set(extype=1, collinear='mcol', collinear_samples=20).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=1, collinear='mcol', collinear_samples=20, state=1)
+        ref = np.array(
+            [
+                [-6.7904482786e-16, 1.2476156342e-14, 3.6571945011e-03],
+                [-9.3757276431e-17, 1.4533596842e-02, -1.8349716472e-03],
+                [4.8848910182e-17, -1.4533596842e-02, -1.8349716472e-03],
+            ]
+        )
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, delta=1e-5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, delta=1e-5)
+
+    def test_col_b3lyp(self):
+        mf = self.mol.UKS(xc='B3LYP').run()
+        td = mf.SFTDA().set(extype=0, collinear='col').run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=0, collinear='col', state=1)
+        ref = np.array(
+            [
+                [-2.5468184163e-16, -1.1180009418e-14, 2.9019466200e-01],
+                [-9.0775873947e-17, 2.8359926220e-01, -1.4509830953e-01],
+                [1.1512910412e-16, -2.8359926220e-01, -1.4509830953e-01],
+            ]
+        )
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, delta=1e-5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, delta=1e-5)
+
+        td = mf.SFTDDFT().set(extype=0, collinear='col').run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=0, collinear='col', state=1)
+        ref = np.array(
+            [
+                [-1.5105624594e-16, 1.2602467888e-15, 2.9075066796e-01],
+                [6.5823041051e-18, 2.8383333522e-01, -1.4537631436e-01],
+                [-7.5347051462e-17, -2.8383333522e-01, -1.4537631436e-01],
+            ]
+        )
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, delta=1e-5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, delta=1e-5)
+
+    def test_mcol_tpss(self):
+        mf = self.mol.UKS(xc='TPSS').run()
+        td = mf.SFTDA().set(extype=1, collinear='mcol', collinear_samples=20).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=1, collinear='mcol', collinear_samples=20, state=1)
+        ref = np.array(
+            [
+                [1.4878309854e-16, 1.8283875050e-14, 8.7167801429e-03],
+                [4.6186501645e-17, 1.4280801923e-02, -4.3644887121e-03],
+                [-1.1302550886e-16, -1.4280801923e-02, -4.3644887121e-03],
+            ]
+        )
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, delta=1e-5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, delta=1e-5)
+
+        td = mf.SFTDDFT().set(extype=0, collinear='mcol', collinear_samples=20).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=0, collinear='mcol', collinear_samples=20, state=1)
+        ref = np.array(
+            [
+                [-2.8308341496e-16, 1.0704054160e-15, 3.0645165527e-01],
+                [-1.1971039167e-16, 2.8704791604e-01, -1.5324080858e-01],
+                [3.3992205735e-17, -2.8704791604e-01, -1.5324080858e-01],
+            ]
+        )
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, delta=1e-5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, delta=1e-5)
+
+
+if __name__ == '__main__':
+    print('Full tests for SF-TDA and SF-TDDFT analytic gradients')
+    unittest.main()

--- a/src/nest/nttda/__init__.py
+++ b/src/nest/nttda/__init__.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Noncollinear tensor TDA methods."""
+
+from nest.nttda.nttda import NTTDA
+
+__all__ = ["NTTDA"]

--- a/src/nest/nttda/nttda.py
+++ b/src/nest/nttda/nttda.py
@@ -1,0 +1,1077 @@
+#!/usr/bin/env python
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Noncollinear-Tensor TDA
+#
+# Author: Tai Wang <wtpeter@pku.edu.cn>
+#
+
+import numpy as np
+from pyscf import lib
+from pyscf import dft
+from pyscf.lib import logger
+from pyscf.scf import hf_symm
+from pyscf.tdscf.uhf import TDBase
+from pyscf.dft.gen_grid import NBINS
+from pyscf import __config__
+from pyscf.dft.numint import _scale_ao_sparse, _dot_ao_ao_sparse, _dot_ao_dm_sparse, _contract_rho_sparse
+from pyscf.tdscf._lr_eig import eigh as lr_eigh
+from pyscf import symm
+from pyscf.data import nist
+
+MO_BASE = getattr(__config__, 'MO_BASE', 1)
+
+def nr_rks_fxc1_gga(ni, mol, grids, xc_code, dms, fxc, max_memory=2000):
+    nset = dms.shape[0]
+    vmat = np.zeros_like(dms)
+
+    nao = mol.nao_nr()
+    ao_loc = mol.ao_loc_nr()
+    cutoff = grids.cutoff * 1e2
+    nbins = NBINS * 2 - int(NBINS * np.log(cutoff) / np.log(grids.cutoff))
+    pair_mask = mol.get_overlap_cond() < -np.log(ni.cutoff)
+
+    aow = None
+    p1 = 0
+    for ao, mask, weight, coords in ni.block_loop(mol, grids, nao, 1, max_memory=max_memory):
+        p0, p1 = p1, p1 + weight.size
+        _fxc = fxc[:, :, p0:p1] * weight
+        for num in range(nset):
+            dm = dms[num]
+            dm = np.asarray(dms[num], order='C')
+            ngrids = ao.shape[1]
+
+            c0 = _dot_ao_dm_sparse(ao[0], dm, nbins, mask, pair_mask, ao_loc)
+            rho0 = _contract_rho_sparse(ao[0], c0, mask, ao_loc)
+            R_grad = np.empty((3, ngrids))
+            for j in range(1, 4):
+                R_grad[j - 1] = _contract_rho_sparse(ao[j], c0, mask, ao_loc)
+            c_grad = []
+            for i in range(1, 4):
+                c_grad.append(_dot_ao_dm_sparse(ao[i], dm, nbins, mask, pair_mask, ao_loc))
+            L_grad = np.empty((3, ngrids))
+            for i in range(1, 4):
+                L_grad[i - 1] = _contract_rho_sparse(ao[0], c_grad[i - 1], mask, ao_loc)
+            tau = np.empty((3, 3, ngrids))
+            for i in range(1, 4):
+                for j in range(1, 4):
+                    tau[i - 1, j - 1] = _contract_rho_sparse(ao[j], c_grad[i - 1], mask, ao_loc)
+
+            U = np.zeros((4, 4, weight.size))
+            U[0, 0] = _fxc[0, 0] * rho0
+            U[0, 0] += lib.einsum('ig,ig->g', _fxc[1:4, 0], L_grad)  # sum_i f_{i0} L_i
+            U[0, 0] += lib.einsum('jg,jg->g', _fxc[0, 1:4], R_grad)  # sum_j f_{0j} R_j
+            U[0, 0] += lib.einsum('ijg,ijg->g', _fxc[1:4, 1:4], tau)
+            U[1:4, 0] += _fxc[1:4, 0] * rho0
+            U[1:4, 0] += lib.einsum('ijg,jg->ig', _fxc[1:4, 1:4], R_grad)
+            U[0, 1:4] += _fxc[0, 1:4] * rho0
+            U[0, 1:4] += lib.einsum('ijg,ig->jg', _fxc[1:4, 1:4], L_grad)
+            U[1:4, 1:4] += _fxc[1:4, 1:4] * rho0
+
+            for i in range(4):
+                wv_i = np.asarray(U[i, :, :], order='C')
+                aow = _scale_ao_sparse(ao, wv_i, mask, ao_loc)
+                v_chunk = _dot_ao_ao_sparse(ao[i], aow, None, nbins, mask, pair_mask, ao_loc, hermi=0, out=None)
+                vmat[num] += v_chunk
+    return vmat
+
+
+def nr_rks_fxc1_mgga(ni, mol, grids, xc_code, dms, fxc, max_memory=2000):
+    nset = dms.shape[0]
+    vmat = np.zeros_like(dms)
+
+    nao = mol.nao_nr()
+    ao_loc = mol.ao_loc_nr()
+    cutoff = grids.cutoff * 1e2
+
+    nbins = NBINS * 2 - int(NBINS * np.log(cutoff) / np.log(grids.cutoff))
+    pair_mask = mol.get_overlap_cond() < -np.log(ni.cutoff)
+
+    aow = None
+    p1 = 0
+    for ao, mask, weight, coords in ni.block_loop(mol, grids, nao, 1, max_memory=max_memory):
+        p0, p1 = p1, p1 + weight.size
+        _fxc = fxc[:, :, p0:p1] * weight
+        for num in range(nset):
+            dm = np.asarray(dms[num], order='C')
+            ngrids = ao.shape[1]
+            c0 = _dot_ao_dm_sparse(ao[0], dm, nbins, mask, pair_mask, ao_loc)
+            rho0 = _contract_rho_sparse(ao[0], c0, mask, ao_loc)
+            R_grad = np.empty((3, ngrids))
+            for j in range(1, 4):
+                R_grad[j - 1] = _contract_rho_sparse(ao[j], c0, mask, ao_loc)
+            c_grad = []
+            for i in range(1, 4):
+                c_grad.append(_dot_ao_dm_sparse(ao[i], dm, nbins, mask, pair_mask, ao_loc))
+            L_grad = np.empty((3, ngrids))
+            for i in range(1, 4):
+                L_grad[i - 1] = _contract_rho_sparse(ao[0], c_grad[i - 1], mask, ao_loc)
+            tau = np.empty((3, 3, ngrids))
+            for i in range(1, 4):
+                for j in range(1, 4):
+                    tau[i - 1, j - 1] = _contract_rho_sparse(ao[j], c_grad[i - 1], mask, ao_loc)
+
+            U = np.zeros((4, 4, weight.size))
+            U[0, 0] = _fxc[0, 0] * rho0
+            U[0, 0] += lib.einsum('ig,ig->g', _fxc[1:4, 0], L_grad)
+            U[0, 0] += lib.einsum('jg,jg->g', _fxc[0, 1:4], R_grad)
+            U[0, 0] += lib.einsum('ijg,ijg->g', _fxc[1:4, 1:4], tau)
+            U[1:4, 0] = _fxc[1:4, 0] * rho0
+            U[1:4, 0] += lib.einsum('ijg,jg->ig', _fxc[1:4, 1:4], R_grad)
+            U[1:4, 0] += 0.5 * _fxc[4, 0].reshape(1, -1) * L_grad
+            U[1:4, 0] += 0.5 * lib.einsum('jg,ijg->ig', _fxc[4, 1:4], tau)
+            U[0, 1:4] = _fxc[0, 1:4] * rho0
+            U[0, 1:4] += lib.einsum('ijg,ig->jg', _fxc[1:4, 1:4], L_grad)
+            U[0, 1:4] += 0.5 * _fxc[0, 4].reshape(1, -1) * R_grad
+            U[0, 1:4] += 0.5 * lib.einsum('ig,ijg->jg', _fxc[1:4, 4], tau)
+            U[1:4, 1:4] = _fxc[1:4, 1:4] * rho0
+            U[1:4, 1:4] += 0.5 * lib.einsum('ig,jg->ijg', _fxc[1:4, 4], R_grad)
+            U[1:4, 1:4] += 0.5 * lib.einsum('jg,ig->ijg', _fxc[4, 1:4], L_grad)
+            U[1:4, 1:4] += 0.25 * _fxc[4, 4].reshape(1, 1, -1) * tau
+
+            for i in range(4):
+                wv_i = np.asarray(U[i, :, :], order='C')
+                aow = _scale_ao_sparse(ao, wv_i, mask, ao_loc)
+                v_chunk = _dot_ao_ao_sparse(ao[i], aow, None, nbins, mask, pair_mask, ao_loc, hermi=0, out=None)
+                vmat[num] += v_chunk
+
+    return vmat
+
+
+def gen_rohf_response_sfu(mf, mo_coeff=None, mo_occ=None, hermi=0, max_memory=None, log=None):
+    '''
+    response function for Sf=Si+1 with K^SF_0 = kernel
+    '''
+    if mo_coeff is None:
+        mo_coeff = mf.mo_coeff
+    if mo_occ is None:
+        mo_occ = mf.mo_occ
+
+    mol = mf.mol
+    if log is None:
+        log = logger.new_logger(mf)
+    if not isinstance(mf, (dft.roks.ROKS, dft.rks_symm.SymAdaptedROKS)):
+        raise TypeError('NTTDA response requires ROKS reference')
+
+    ni = mf._numint
+    ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
+    omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
+    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    xctype = ni._xc_type(mf.xc)
+    if xctype != 'HF':
+        fxc_d0 = ni.cache_xc_kernel(mol, mf.grids, mf.xc, mo_coeff, mo_occ, 1)[2]
+        fxc_ref = 0.5 * (fxc_d0[0, :, 0] - fxc_d0[0, :, 1] - fxc_d0[1, :, 0] + fxc_d0[1, :, 1])
+
+    if max_memory is None:
+        mem_now = lib.current_memory()[0]
+        max_memory = max(2000, mf.max_memory*.8-mem_now)
+
+    if mf.do_nlc():
+        logger.warn(mf, "NLC contribution in gen_response is NOT included")
+
+    def vind(dms_cv):
+        if xctype != 'HF':
+            time_xc = (logger.process_clock(), logger.perf_counter())
+            v1ao_cv = ni.nr_rks_fxc(mol, mf.grids, mf.xc, None, dms_cv, 0, hermi,
+                                    None, None, fxc_ref, max_memory=max_memory)
+            time_xc = log.timer('NTTDA response_sfu kernel v1ao_cv', *time_xc)
+        else:
+            v1ao_cv = np.zeros_like(dms_cv)
+
+        if hybrid:
+            time_jk = (logger.process_clock(), logger.perf_counter())
+            vk = mf.get_k(mol, dms_cv, hermi) * hyb
+            if omega != 0:
+                vk += mf.get_k(mol, dms_cv, hermi, omega=omega) * (alpha - hyb)
+            v1ao_cv -= vk
+            log.timer('NTTDA response_sfu kernel get_k total', *time_jk)
+        return v1ao_cv
+
+    orbos = mo_coeff[:, np.where(mo_occ == 1)[0]]
+    dmoo = orbos @ orbos.T
+    if xctype != 'HF':
+        delta = ni.nr_rks_fxc(mol, mf.grids, mf.xc, None, dmoo, 0, 1, None, None, fxc_ref, max_memory=max_memory)
+    else:
+        delta = np.zeros_like(dmoo)
+    if hybrid:
+        delta -= mf.get_k(mol, dmoo, 1) * hyb
+        if omega != 0:
+            delta -= mf.get_k(mol, dmoo, 1, omega=omega) * (alpha - hyb)
+    return vind, 0.5 * delta
+
+def gen_rohf_response_sc(mf, mo_coeff=None, mo_occ=None, hermi=0, max_memory=None, log=None):
+    '''
+    response function for Sf=Si
+    '''
+    if mo_coeff is None:
+        mo_coeff = mf.mo_coeff
+    if mo_occ is None:
+        mo_occ = mf.mo_occ
+
+    mol = mf.mol
+    if log is None:
+        log = logger.new_logger(mf)
+    if not isinstance(mf, (dft.roks.ROKS, dft.rks_symm.SymAdaptedROKS)):
+        raise TypeError('NTTDA response requires ROKS reference')
+
+    s = (mol.nelec[0] - mol.nelec[1]) * 0.5
+
+    ni = mf._numint
+    ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
+    omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
+    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    xctype = ni._xc_type(mf.xc)
+    if xctype != 'HF':
+        fxc_d0 = ni.cache_xc_kernel(mol, mf.grids, mf.xc, mo_coeff, mo_occ, 1)[2]
+        fxc_ref = 0.5 * (fxc_d0[0, :, 0] - fxc_d0[0, :, 1] - fxc_d0[1, :, 0] + fxc_d0[1, :, 1])
+
+    if max_memory is None:
+        mem_now = lib.current_memory()[0]
+        max_memory = max(2000, mf.max_memory*.8-mem_now)
+
+    if mf.do_nlc():
+        logger.warn(mf, "NLC contribution in gen_response is NOT included")
+
+    def vind(dms_co, dms_cv, dms_ov, dms_cv0):
+        n_co = len(dms_co)
+        n_cv = len(dms_cv)
+        n_ov = len(dms_ov)
+        idx1 = n_co
+        idx2 = idx1 + n_cv
+        idx3 = idx2 + n_ov
+
+        v1ao_co = np.zeros_like(dms_co)
+        v1ao_cv = np.zeros_like(dms_cv)
+        v1ao_ov = np.zeros_like(dms_ov)
+        v1ao_cv0 = np.zeros_like(dms_cv0)
+
+        dms0 = np.concatenate((dms_co, dms_cv, dms_ov, dms_cv0), axis=0)
+        dms1 = np.concatenate((dms_co, dms_ov, dms_cv0), axis=0)
+
+        # kernel part
+        if xctype != 'HF':
+            time_xc = (logger.process_clock(), logger.perf_counter())
+            vref0 = ni.nr_rks_fxc(mol, mf.grids, mf.xc, None, dms0, 0, hermi,
+                                  None, None, fxc_ref, max_memory=max_memory)
+            time_xc = log.timer('NTTDA response_sc kernel vref0', *time_xc)
+            if xctype == 'LDA':
+                vref1 = ni.nr_rks_fxc(mol, mf.grids, mf.xc, None, dms1, 0, hermi,
+                                      None, None, fxc_ref, max_memory=max_memory)
+            elif xctype =='GGA':
+                vref1 = nr_rks_fxc1_gga(ni, mol, mf.grids, mf.xc, dms1, fxc_ref, max_memory=max_memory)
+            elif xctype == 'MGGA':
+                vref1 = nr_rks_fxc1_mgga(ni, mol, mf.grids, mf.xc, dms1, fxc_ref, max_memory=max_memory)
+            log.timer('NTTDA response_sc kernel vref1', *time_xc)
+        else:
+            vref0 = np.zeros_like(dms0)
+            vref1 = np.zeros_like(dms1)
+
+        if hybrid:
+            time_jk = (logger.process_clock(), logger.perf_counter())
+            vk = mf.get_k(mol, dms0, hermi) * hyb
+            vj = mf.get_j(mol, dms1, hermi) * hyb
+            if omega != 0:
+                vk += mf.get_k(mol, dms0, hermi, omega=omega) * (alpha - hyb)
+                vj += mf.get_j(mol, dms1, hermi, omega=omega) * (alpha - hyb)
+            vref0 -= vk
+            vref1 -= vj
+            log.timer('NTTDA response_sc kernel get_j/get_k total', *time_jk)
+
+        vref0_co = vref0[:idx1]
+        vref0_cv = vref0[idx1:idx2]
+        vref0_ov = vref0[idx2:idx3]
+        vref0_cv0 = vref0[idx3:]
+        vref1_co = vref1[:idx1]
+        vref1_ov = vref1[idx1:idx1+n_ov]
+        vref1_cv0 = vref1[idx1+n_ov:]
+
+        v1ao_co += vref0_co - vref1_co + np.sqrt((s + 1) / 2 / s) * vref0_cv + vref1_ov
+        v1ao_cv += np.sqrt((s + 1) / 2 / s) * vref0_co + vref0_cv + np.sqrt((s + 1) / 2 / s) * vref0_ov
+        v1ao_ov += vref1_co + np.sqrt((s + 1) / 2 / s) * vref0_cv - vref1_ov + vref0_ov
+        v1ao_co += np.sqrt(0.5) * vref0_cv0 - np.sqrt(2.0) * vref1_cv0
+        v1ao_ov += -np.sqrt(0.5) * vref0_cv0 + np.sqrt(2.0) * vref1_cv0
+        v1ao_cv0 += np.sqrt(0.5) * vref0_co - np.sqrt(2.0) * vref1_co
+        v1ao_cv0 += -np.sqrt(0.5) * vref0_ov + np.sqrt(2.0) * vref1_ov
+        v1ao_cv0 += vref0_cv0 - 2.0 * vref1_cv0
+        return v1ao_co, v1ao_cv, v1ao_ov, v1ao_cv0
+
+    orbos = mo_coeff[:, np.where(mo_occ == 1)[0]]
+    dmoo = orbos @ orbos.T
+    if xctype != 'HF':
+        delta = ni.nr_rks_fxc(mol, mf.grids, mf.xc, None, dmoo, 0, 1, None, None, fxc_ref, max_memory=max_memory)
+    else:
+        delta = np.zeros_like(dmoo)
+    if hybrid:
+        delta -= mf.get_k(mol, dmoo, 1) * hyb
+        if omega != 0:
+            delta -= mf.get_k(mol, dmoo, 1, omega=omega) * (alpha - hyb)
+    return vind, 0.5 * delta
+
+def gen_rohf_response_sfd(mf, mo_coeff=None, mo_occ=None, hermi=0, max_memory=None, log=None):
+    '''
+    response function for Sf=Si-1
+    '''
+    if mo_coeff is None:
+        mo_coeff = mf.mo_coeff
+    if mo_occ is None:
+        mo_occ = mf.mo_occ
+
+    mol = mf.mol
+    if log is None:
+        log = logger.new_logger(mf)
+    if not isinstance(mf, (dft.roks.ROKS, dft.rks_symm.SymAdaptedROKS)):
+        raise TypeError('NTTDA response requires ROKS reference')
+
+    s = (mol.nelec[0] - mol.nelec[1]) * 0.5
+
+    ni = mf._numint
+    ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
+    omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
+    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    xctype = ni._xc_type(mf.xc)
+
+    if xctype != 'HF':
+        fxc_d0 = ni.cache_xc_kernel(mol, mf.grids, mf.xc, mo_coeff, mo_occ, 1)[2]
+        fxc_ref = 0.5 * (fxc_d0[0, :, 0] - fxc_d0[0, :, 1] - fxc_d0[1, :, 0] + fxc_d0[1, :, 1])
+
+    if max_memory is None:
+        mem_now = lib.current_memory()[0]
+        max_memory = max(2000, mf.max_memory*.8-mem_now)
+
+    if mf.do_nlc():
+        logger.warn(mf, "NLC contribution in gen_response is NOT included")
+
+    def vind(dms_co, dms_cv, dms_oo, dms_ov):
+        n_co = len(dms_co)
+        n_cv = len(dms_cv)
+        n_oo = len(dms_oo)
+        idx1 = n_co
+        idx2 = n_co + n_cv
+        idx3 = n_co + n_cv + n_oo
+
+        v1ao_co = np.zeros_like(dms_co)
+        v1ao_cv = np.zeros_like(dms_cv)
+        v1ao_oo = np.zeros_like(dms_oo)
+        v1ao_ov = np.zeros_like(dms_ov)
+
+        dms0 = np.concatenate((dms_co, dms_cv, dms_oo, dms_ov), axis=0)
+        dms1 = np.concatenate((dms_co, dms_ov), axis=0)
+
+        if xctype != 'HF':
+            time_xc = (logger.process_clock(), logger.perf_counter())
+            vref0 = ni.nr_rks_fxc(mol, mf.grids, mf.xc, None, dms0, 0, hermi,
+                                  None, None, fxc_ref, max_memory=max_memory)
+            time_xc = log.timer('NTTDA response_sf vref0', *time_xc)
+            if xctype == 'LDA':
+                vref1 = ni.nr_rks_fxc(mol, mf.grids, mf.xc, None, dms1, 0, hermi,
+                                      None, None, fxc_ref, max_memory=max_memory)
+            elif xctype =='GGA':
+                vref1 = nr_rks_fxc1_gga(ni, mol, mf.grids, mf.xc, dms1, fxc_ref, max_memory=max_memory)
+            elif xctype == 'MGGA':
+                vref1 = nr_rks_fxc1_mgga(ni, mol, mf.grids, mf.xc, dms1, fxc_ref, max_memory=max_memory)
+            log.timer('NTTDA response_sf vref1', *time_xc)
+        else:
+            vref0 = np.zeros_like(dms0)
+            vref1 = np.zeros_like(dms1)
+
+        # HF part
+        if hybrid:
+            time_jk = (logger.process_clock(), logger.perf_counter())
+            vk = mf.get_k(mol, dms0, hermi) * hyb
+            vj = mf.get_j(mol, dms1, hermi) * hyb
+            if omega != 0:
+                vk += mf.get_k(mol, dms0, hermi, omega=omega) * (alpha - hyb)
+                vj += mf.get_j(mol, dms1, hermi, omega=omega) * (alpha - hyb)
+            vref0 -= vk
+            vref1 -= vj
+            log.timer('NTTDA response_sf get_j/get_k total', *time_jk)
+        vref0_co = vref0[:idx1]
+        vref0_cv = vref0[idx1:idx2]
+        vref0_oo = vref0[idx2:idx3]
+        vref0_ov = vref0[idx3:]
+        vref1_co = vref1[:idx1]
+        vref1_ov = vref1[idx1:]
+
+        v1ao_co += vref0_co + vref1_co / (2 * s - 1) + np.sqrt((2 * s + 1) / 2 / s) * vref0_cv
+        v1ao_co += np.sqrt(2 * s / (2 * s - 1)) * vref0_oo + 2 * s / (2 * s - 1) * vref0_ov - vref1_ov / (2 * s - 1)
+        v1ao_cv += vref0_co * np.sqrt((2 * s + 1) / 2 / s) + vref0_cv + np.sqrt((2 * s + 1) / (2 * s - 1)) * vref0_oo
+        v1ao_cv += np.sqrt((2 * s + 1) / 2 / s) * vref0_ov
+        v1ao_oo += np.sqrt(2 * s / (2 * s - 1)) * vref0_co + np.sqrt((2 * s + 1) / (2 * s - 1)) * vref0_cv
+        v1ao_oo += vref0_oo + np.sqrt(2 * s / (2 * s - 1)) * vref0_ov
+        v1ao_ov += 2 * s / (2 * s - 1) * vref0_co - vref1_co / (2 * s - 1) + np.sqrt((2 * s + 1) / 2 / s) * vref0_cv
+        v1ao_ov += np.sqrt(2 * s / (2 * s - 1)) * vref0_oo + vref0_ov + vref1_ov / (2 * s - 1)
+
+        return v1ao_co, v1ao_cv, v1ao_oo, v1ao_ov
+
+    orbos = mo_coeff[:, np.where(mo_occ == 1)[0]]
+    dmoo = orbos @ orbos.T
+    if xctype != 'HF':
+        delta = ni.nr_rks_fxc(mol, mf.grids, mf.xc, None, dmoo, 0, 1, None, None, fxc_ref, max_memory=max_memory)
+    else:
+        delta = np.zeros_like(dmoo)
+    if hybrid:
+        delta -= mf.get_k(mol, dmoo, 1) * hyb
+        if omega != 0:
+            delta -= mf.get_k(mol, dmoo, 1, omega=omega) * (alpha - hyb)
+    return vind, 0.5 * delta
+
+
+def gen_vind_sfu(td):
+    mf = td._scf
+    mo_coeff = mf.mo_coeff
+    assert mo_coeff[0].dtype == np.double
+    mo_occ = mf.mo_occ
+
+    csidx, _, vsidx = _orbital_indices(td)
+    orbcs = mo_coeff[:, csidx]
+    orbvs = mo_coeff[:, vsidx]
+    ncs = orbcs.shape[1]
+    nvs = orbvs.shape[1]
+
+    log = logger.new_logger(td)
+    vresp, fockz = gen_rohf_response_sfu(mf, mo_coeff=mo_coeff, mo_occ=mo_occ, hermi=0,
+                                         max_memory=td.max_memory, log=log)
+
+    if td.nobeta:
+        dma, dmb = mf.make_rdm1()
+        dm0 = 0.5 * (dma + dmb)
+        fock = mf.get_fock(dm=np.array([dm0, dm0]))
+        fock0 = 0.5 * (fock.focka + fock.fockb)
+        focka = fock0 + fockz
+        fockb = fock0 - fockz
+    else:
+        fock = mf.get_fock()
+        fock0 = 0.5 * (fock.focka + fock.fockb)
+        focka = fock0 + fockz
+        fockb = fock0 - fockz
+
+    fock_v = orbvs.T @ focka @ orbvs
+    fock_c = orbcs.T @ fockb @ orbcs
+    hdiag = (fock_v.diagonal()[None, :] - fock_c.diagonal()[:, None]).ravel()
+
+    def vind(zs):
+        time0 = time1 = (logger.process_clock(), logger.perf_counter())
+        zs = np.asarray(zs).reshape(-1, ncs, nvs)
+        dms_cv = lib.einsum('xia,pa,qi->xpq', zs, orbvs, orbcs.conj())
+        time1 = log.timer('NTTDA gen_vind_sfu make density matrices', *time1)
+
+        v1ao_cv = vresp(dms_cv)
+        time1 = log.timer('NTTDA gen_vind_sfu response vind total', *time1)
+        v1mo_cv = lib.einsum('xpq,qi,pa->xia', v1ao_cv, orbcs, orbvs.conj())
+        time1 = log.timer('NTTDA gen_vind_sfu AO->MO transform', *time1)
+
+        v1mo_cv += lib.einsum('ab,xib->xia', fock_v, zs)
+        v1mo_cv -= lib.einsum('ji,xja->xia', fock_c, zs)
+        time1 = log.timer('NTTDA gen_vind_sfu Fock part', *time1)
+
+        v1mo = v1mo_cv.reshape(len(zs), -1)
+        time1 = log.timer('NTTDA gen_vind_sfu pack result', *time1)
+        log.timer('NTTDA gen_vind_sfu total', *time0)
+        return v1mo
+    return vind, hdiag
+
+def gen_vind_sc(td):
+    mf = td._scf
+    mo_coeff = mf.mo_coeff
+    assert mo_coeff[0].dtype == np.double
+    mo_occ = mf.mo_occ
+
+    csidx, osidx, vsidx = _orbital_indices(td)
+    orbcs = mo_coeff[:, csidx]
+    orbos = mo_coeff[:, osidx]
+    orbvs = mo_coeff[:, vsidx]
+    ncs = orbcs.shape[1]
+    nos = orbos.shape[1]
+    nvs = orbvs.shape[1]
+    slices = _sc_vector_slices(ncs, nos, nvs)
+
+    s = nos * 0.5
+    assert s >= 0.5, 'NTTDA only supports case that Sf=Si>=1/2.'
+    assert s == (mf.mol.nelec[0] - mf.mol.nelec[1]) * 0.5
+
+    log = logger.new_logger(td)
+    vresp, fockz = gen_rohf_response_sc(mf, mo_coeff=mo_coeff, mo_occ=mo_occ, hermi=0,
+                                        max_memory=td.max_memory, log=log)
+
+    if td.nobeta:
+        dma, dmb = mf.make_rdm1()
+        dm0 = 0.5 * (dma + dmb)
+        fock = mf.get_fock(dm=np.array([dm0, dm0]))
+        fock0 = 0.5 * (fock.focka + fock.fockb)
+        focka = fock0 + fockz
+        fockb = fock0 - fockz
+    else:
+        fock = mf.get_fock()
+        fock0 = 0.5 * (fock.focka + fock.fockb)
+        focka = fock0 + fockz
+        fockb = fock0 - fockz
+
+    fock_coco1 = orbos.T @ (fock0 - fockz) @ orbos
+    fock_coco2 = orbcs.T @ (fock0 - fockz) @ orbcs
+    fock_cocv = orbos.T @ (fock0 - fockz) @ orbvs
+    fock_cvcv1 = orbvs.T @ (fock0 - fockz / s) @ orbvs
+    fock_cvcv2 = orbcs.T @ (fock0 + fockz / s) @ orbcs
+    fock_cocv0 = orbos.T @ fockb @ orbvs
+    fock_cvov = orbos.T @ (fock0 + fockz) @ orbcs
+    fock_cvcv01 = 0.5 * orbvs.T @ (focka - fockb) @ orbvs
+    fock_cvcv02 = 0.5 * orbcs.T @ (focka - fockb) @ orbcs
+    fock_ovov1 = orbvs.T @ (fock0 + fockz) @ orbvs
+    fock_ovov2 = orbos.T @ (fock0 + fockz) @ orbos
+    fock_ovcv0 = orbcs.T @ focka @ orbos
+    fock_cv0cv01 = 0.5 * orbvs.T @ (focka + fockb) @ orbvs
+    fock_cv0cv02 = 0.5 * orbcs.T @ (focka + fockb) @ orbcs
+    fock_cooo = orbos.T @ (fock0 - fockz) @ orbcs
+    fock_cvoo = orbvs.T @ fockz @ orbcs
+    fock_ovoo = orbvs.T @ (fock0 + fockz) @ orbos
+    fock_cv0oo = 0.5 * orbvs.T @ (focka + fockb) @ orbcs
+
+    # diagonal part for preconditioning
+    hdiag_co = (fock_coco1.diagonal()[None, :] - fock_coco2.diagonal()[:, None]).ravel()
+    hdiag_cv = (fock_cvcv1.diagonal()[None, :] - fock_cvcv2.diagonal()[:, None]).ravel()
+    hdiag_oo = np.array([0.0])
+    hdiag_ov = (fock_ovov1.diagonal()[None, :] - fock_ovov2.diagonal()[:, None]).ravel()
+    hdiag_cv0 = (fock_cv0cv01.diagonal()[None, :] - fock_cv0cv02.diagonal()[:, None]).ravel()
+    hdiag = np.concatenate((hdiag_co, hdiag_cv, hdiag_oo, hdiag_ov, hdiag_cv0))
+
+    def vind(zs):
+        time0 = time1 = (logger.process_clock(), logger.perf_counter())
+        zs = np.asarray(zs)  # (nstates, ndim)
+        zs_co = zs[:, slices['CO(1)']].reshape(-1, ncs, nos)
+        zs_cv = zs[:, slices['CV(1)']].reshape(-1, ncs, nvs)
+        zs_oo = zs[:, slices['OO(1)']].reshape(-1, 1)
+        zs_ov = zs[:, slices['OV(1)']].reshape(-1, nos, nvs)
+        zs_cv0 = zs[:, slices['CV(0)']].reshape(-1, ncs, nvs)
+        dms_co = lib.einsum('xov,pv,qo->xpq', zs_co, orbos, orbcs.conj())
+        dms_cv = lib.einsum('xov,pv,qo->xpq', zs_cv, orbvs, orbcs.conj())
+        dms_ov = lib.einsum('xov,pv,qo->xpq', zs_ov, orbvs, orbos.conj())
+        dms_cv0 = lib.einsum('xov,pv,qo->xpq', zs_cv0, orbvs, orbcs.conj())
+        time1 = log.timer('NTTDA gen_vind_sc make density matrices', *time1)
+        v1ao_co, v1ao_cv, v1ao_ov, v1ao_cv0 = vresp(dms_co, dms_cv, dms_ov, dms_cv0)
+        time1 = log.timer('NTTDA gen_vind_sc response vind total', *time1)
+        v1mo_co = lib.einsum('xpq,qo,pv->xov', v1ao_co, orbcs, orbos.conj())
+        v1mo_cv = lib.einsum('xpq,qo,pv->xov', v1ao_cv, orbcs, orbvs.conj())
+        v1mo_ov = lib.einsum('xpq,qo,pv->xov', v1ao_ov, orbos, orbvs.conj())
+        v1mo_cv0 = lib.einsum('xpq,qo,pv->xov', v1ao_cv0, orbcs, orbvs.conj())
+        time1 = log.timer('NTTDA gen_vind_sc AO->MO transform', *time1)
+
+        v1mo_co += lib.einsum('uv,xiv->xiu', fock_coco1, zs_co)
+        v1mo_co -= lib.einsum('ji,xju->xiu', fock_coco2, zs_co)
+        v1mo_co += lib.einsum('ub,xib->xiu', fock_cocv, zs_cv) * np.sqrt((s + 1) / 2 / s)
+        v1mo_co -= np.einsum('ui,xv->xiu', fock_cooo, zs_oo)
+        v1mo_co += lib.einsum('ub,xib->xiu', fock_cocv0, zs_cv0) * np.sqrt(0.5)
+
+        v1mo_cv += lib.einsum('av,xiv->xia', fock_cocv.T, zs_co) * np.sqrt((s + 1) / 2 / s)
+        v1mo_cv += lib.einsum('ab,xib->xia', fock_cvcv1, zs_cv)
+        v1mo_cv -= lib.einsum('ji,xja->xia', fock_cvcv2, zs_cv)
+        v1mo_cv += np.einsum('ai,xv->xia', fock_cvoo, zs_oo) * np.sqrt(2 * (s + 1) / s)
+        v1mo_cv -= lib.einsum('vi,xva->xia', fock_cvov, zs_ov) * np.sqrt((s + 1) / 2 / s)
+        v1mo_cv -= lib.einsum('ab,xib->xia', fock_cvcv01, zs_cv0) * np.sqrt((s + 1) / s)
+        v1mo_cv += lib.einsum('ji,xja->xia', fock_cvcv02, zs_cv0) * np.sqrt((s + 1) / s)
+
+        v1mo_ov -= lib.einsum('ju,xja->xua', fock_cvov.T, zs_cv) * np.sqrt((s + 1) / 2 / s)
+        v1mo_ov += np.einsum('au,xv->xua', fock_ovoo, zs_oo)
+        v1mo_ov += lib.einsum('ab,xub->xua', fock_ovov1, zs_ov)
+        v1mo_ov -= lib.einsum('vu,xva->xua', fock_ovov2, zs_ov)
+        v1mo_ov += lib.einsum('ju,xja->xua', fock_ovcv0, zs_cv0) * np.sqrt(0.5)
+
+        v1mo_cv0 += lib.einsum('av,xiv->xia', fock_cocv0.T, zs_co) * np.sqrt(0.5)
+        v1mo_cv0 -= lib.einsum('ab,xib->xia', fock_cvcv01, zs_cv) * np.sqrt((s + 1) / s)
+        v1mo_cv0 += lib.einsum('ji,xja->xia', fock_cvcv02, zs_cv) * np.sqrt((s + 1) / s)
+        v1mo_cv0 -= np.einsum('ai,xv->xia', fock_cv0oo, zs_oo) * np.sqrt(2)
+        v1mo_cv0 += lib.einsum('vi,xva->xia', fock_ovcv0.T, zs_ov) * np.sqrt(0.5)
+        v1mo_cv0 += lib.einsum('ab,xib->xia', fock_cv0cv01, zs_cv0)
+        v1mo_cv0 -= lib.einsum('ji,xja->xia', fock_cv0cv02, zs_cv0)
+
+        v1mo_oo = np.zeros((len(zs), ))
+        v1mo_oo -= lib.einsum('jv,xjv->x', fock_cooo.T, zs_co)
+        v1mo_oo += lib.einsum('jb,xjb->x', fock_cvoo.T, zs_cv) * np.sqrt(2 * (s + 1) / s)
+        v1mo_oo += lib.einsum('vb,xvb->x', fock_ovoo.T, zs_ov)
+        v1mo_oo -= lib.einsum('jb,xjb->x', fock_cv0oo.T, zs_cv0) * np.sqrt(2)
+        time1 = log.timer('NTTDA gen_vind_sc Fock part', *time1)
+
+        v1mo = np.concatenate((v1mo_co.reshape(len(zs), -1),
+                                v1mo_cv.reshape(len(zs), -1),
+                                v1mo_oo.reshape(len(zs), -1),
+                                v1mo_ov.reshape(len(zs), -1),
+                                v1mo_cv0.reshape(len(zs), -1)), axis=1)
+        assert v1mo.shape == zs.shape
+        time1 = log.timer('NTTDA gen_vind_sc pack result', *time1)
+        log.timer('NTTDA gen_vind_sc total', *time0)
+        return v1mo
+    return vind, hdiag
+
+def gen_vind_sfd(td):
+    mf = td._scf
+    mo_coeff = mf.mo_coeff
+    assert mo_coeff[0].dtype == np.double
+    mo_occ = mf.mo_occ
+
+    csidx, osidx, vsidx = _orbital_indices(td)
+    orbcs = mo_coeff[:, csidx]
+    orbos = mo_coeff[:, osidx]
+    orbvs = mo_coeff[:, vsidx]
+    ncs = orbcs.shape[1]
+    nos = orbos.shape[1]
+    nvs = orbvs.shape[1]
+    nocc = ncs + nos
+    nvir = nos + nvs
+    core_rows = slice(None, ncs)
+    open_rows = slice(ncs, None)
+    open_cols = slice(None, nos)
+    virt_cols = slice(nos, None)
+
+    s = nos * 0.5
+    assert s >= 0.5, 'NTTDA for Sf=Si-1 only supports case that Si>=1.'
+    assert s == (mf.mol.nelec[0] - mf.mol.nelec[1]) * 0.5
+
+    log = logger.new_logger(td)
+    vresp, fockz = gen_rohf_response_sfd(mf, mo_coeff=mo_coeff, mo_occ=mo_occ, hermi=0,
+                                         max_memory=td.max_memory, log=log)
+
+    if td.nobeta:
+        dma, dmb = mf.make_rdm1()
+        dm0 = 0.5 * (dma + dmb)
+        fock = mf.get_fock(dm=np.array([dm0, dm0]))
+        fock0 = 0.5 * (fock.focka + fock.fockb)
+    else:
+        fock = mf.get_fock()
+        fock0 = 0.5 * (fock.focka + fock.fockb)
+
+    fock_coco0 = orbos.T @ (fock0 - fockz) @ orbos
+    fock_coco1 = orbcs.T @ (fock0 + fockz) @ orbcs
+    fock_coco2 = orbcs.T @ fockz @ orbcs
+    fock_cocv = orbos.T @ (fock0 - fockz) @ orbvs
+    fock_cooo0 = orbos.T @ (fock0 + fockz) @ orbcs
+    fock_cooo1 = orbos.T @ (fock0 - fockz) @ orbcs
+    fock_cvcv0 = orbvs.T @ (fock0 - fockz) @ orbvs
+    fock_cvcv1 = fock_coco1
+    fock_cvcv2 = orbvs.T @ fockz @ orbvs
+    fock_cvcv3 = fock_coco2
+    fock_cvoo = orbvs.T @ fockz @ orbcs
+    fock_cvov = fock_cooo0
+    fock_oooo0 = fock_coco0
+    fock_oooo1 = orbos.T @ (fock0 + fockz) @ orbos
+    fock_ooov0 = fock_cocv
+    fock_ooov1 = orbos.T @ (fock0 + fockz) @ orbvs
+    fock_ovov0 = fock_cvcv0
+    fock_ovov1 = fock_oooo1
+    fock_ovov2 = fock_cvcv2
+
+    # diagonal part for preconditioning
+    hdiag_co = fock_coco0.diagonal()[None, :] - fock_coco1.diagonal()[:, None]
+    hdiag_co -= fock_coco2.diagonal()[:, None] * 2 / (2 * s - 1)
+    hdiag_cv = fock_cvcv0.diagonal()[None, :] - fock_cvcv1.diagonal()[:, None]
+    hdiag_cv -= fock_cvcv2.diagonal()[None, :] / s + fock_cvcv3.diagonal()[:, None] / s
+    hdiag_oo = fock_oooo0.diagonal()[None, :] - fock_oooo1.diagonal()[:, None]
+    hdiag_ov = fock_ovov0.diagonal()[None, :] - fock_ovov1.diagonal()[:, None]
+    hdiag_ov -= fock_ovov2.diagonal()[None, :] * 2 / (2 * s - 1)
+    hdiag = np.block([[hdiag_co, hdiag_cv], [hdiag_oo, hdiag_ov]]).ravel()
+    open_diag = np.diag_indices(nos)
+
+    def vind(zs):
+        time0 = time1 = (logger.process_clock(), logger.perf_counter())
+        zs = np.asarray(zs).reshape(-1, nocc, nvir)
+        zs_co = zs[:, core_rows, open_cols]
+        zs_cv = zs[:, core_rows, virt_cols]
+        zs_oo = zs[:, open_rows, open_cols]
+        zs_ov = zs[:, open_rows, virt_cols]
+        dms_co = lib.einsum('xov,pv,qo->xpq', zs_co, orbos, orbcs.conj())
+        dms_cv = lib.einsum('xov,pv,qo->xpq', zs_cv, orbvs, orbcs.conj())
+        dms_oo = lib.einsum('xov,pv,qo->xpq', zs_oo, orbos, orbos.conj())
+        dms_ov = lib.einsum('xov,pv,qo->xpq', zs_ov, orbvs, orbos.conj())
+        time1 = log.timer('NTTDA gen_vind_sfd make density matrices', *time1)
+        v1ao_co, v1ao_cv, v1ao_oo, v1ao_ov = vresp(dms_co, dms_cv, dms_oo, dms_ov)
+        time1 = log.timer('NTTDA gen_vind_sfd response vind total', *time1)
+        v1mo_co = lib.einsum('xpq,qo,pv->xov', v1ao_co, orbcs, orbos.conj())
+        v1mo_cv = lib.einsum('xpq,qo,pv->xov', v1ao_cv, orbcs, orbvs.conj())
+        v1mo_oo = lib.einsum('xpq,qo,pv->xov', v1ao_oo, orbos, orbos.conj())
+        v1mo_ov = lib.einsum('xpq,qo,pv->xov', v1ao_ov, orbos, orbvs.conj())
+        time1 = log.timer('NTTDA gen_vind_sfd AO->MO transform', *time1)
+
+        v1mo_co += lib.einsum('uv,xiv->xiu', fock_coco0, zs_co)
+        v1mo_co -= lib.einsum('ji,xju->xiu', fock_coco1, zs_co)
+        v1mo_co -= lib.einsum('ji,xju->xiu', fock_coco2, zs_co) * 2 / (2 * s - 1)
+        v1mo_co += lib.einsum('ub,xib->xiu', fock_cocv, zs_cv) * np.sqrt((2 * s + 1) / 2 / s)
+        v1mo_co -= lib.einsum('wi,xwu->xiu', fock_cooo0, zs_oo) * np.sqrt(2 * s / (2 * s - 1))
+        v1mo_co += lib.einsum('ui,xvv->xiu', fock_cooo1, zs_oo) / np.sqrt(2 * s * (2 * s - 1))
+
+        v1mo_cv += lib.einsum('av,xiv->xia', fock_cocv.T, zs_co) * np.sqrt((2 * s + 1) / 2 / s)
+        v1mo_cv += lib.einsum('ab,xib->xia', fock_cvcv0, zs_cv)
+        v1mo_cv -= lib.einsum('ji,xja->xia', fock_cvcv1, zs_cv)
+        v1mo_cv -= lib.einsum('ab,xib->xia', fock_cvcv2, zs_cv) / s
+        v1mo_cv -= lib.einsum('ji,xja->xia', fock_cvcv3, zs_cv) / s
+        v1mo_cv -= lib.einsum('ai,xvv->xia', fock_cvoo, zs_oo) / s * np.sqrt((2 * s + 1) / (2 * s - 1))
+        v1mo_cv -= lib.einsum('vi,xva->xia', fock_cvov, zs_ov) * np.sqrt((2 * s + 1) / 2 / s)
+
+        v1mo_oo -= lib.einsum('ju,xjt->xut', fock_cooo0.T, zs_co) * np.sqrt(2 * s / (2 * s - 1))
+        v1mo_oo[:, open_diag[0], open_diag[1]] += (
+            lib.einsum('jv,xjv->x', fock_cooo1.T, zs_co) /
+            np.sqrt(2 * s * (2 * s - 1))
+        )[:, None]
+        v1mo_oo[:, open_diag[0], open_diag[1]] -= (
+            lib.einsum('jb,xjb->x', fock_cvoo.T, zs_cv) /
+            s * np.sqrt((2 * s + 1) / (2 * s - 1))
+        )[:, None]
+        v1mo_oo += lib.einsum('tv,xuv->xut', fock_oooo0, zs_oo)
+        v1mo_oo -= lib.einsum('wu,xwt->xut', fock_oooo1, zs_oo)
+        v1mo_oo += lib.einsum('tb,xub->xut', fock_ooov0, zs_ov) * np.sqrt(2 * s / (2 * s - 1))
+        v1mo_oo[:, open_diag[0], open_diag[1]] -= (
+            lib.einsum('vb,xvb->x', fock_ooov1, zs_ov) /
+            np.sqrt(2 * s * (2 * s - 1))
+        )[:, None]
+
+        v1mo_ov -= lib.einsum('ju,xja->xua', fock_cvov.T, zs_cv) * np.sqrt((2 * s + 1) / 2 / s)
+        v1mo_ov += lib.einsum('av,xuv->xua', fock_ooov0.T, zs_oo) * np.sqrt(2 * s / (2 * s - 1))
+        v1mo_ov -= lib.einsum('au,xvv->xua', fock_ooov1.T, zs_oo) / np.sqrt(2 * s * (2 * s - 1))
+        v1mo_ov += lib.einsum('ab,xub->xua', fock_ovov0, zs_ov)
+        v1mo_ov -= lib.einsum('vu,xva->xua', fock_ovov1, zs_ov)
+        v1mo_ov -= lib.einsum('ab,xub->xua', fock_ovov2, zs_ov) * 2 / (2 * s - 1)
+        time1 = log.timer('NTTDA gen_vind_sfd Fock part', *time1)
+
+        v1mo = np.zeros_like(zs)
+        v1mo[:, core_rows, open_cols] = v1mo_co
+        v1mo[:, core_rows, virt_cols] = v1mo_cv
+        v1mo[:, open_rows, open_cols] = v1mo_oo
+        v1mo[:, open_rows, virt_cols] = v1mo_ov
+        assert v1mo.shape == zs.shape
+        time1 = log.timer('NTTDA gen_vind_sfd pack result', *time1)
+        log.timer('NTTDA gen_vind_sfd total', *time0)
+        return v1mo.reshape(len(v1mo), -1)
+    return vind, hdiag
+
+
+class NTTDA(TDBase):
+    '''
+    Noncollinear-Tensor TDA
+    deltaS: -1 for Sf=Si-1, 0 for Sf=Si, 1 for Sf=Si+1
+    nobeta: True for problemstic cases where there is no local beta electrons
+    '''
+
+    deltaS = -1
+    nobeta = False
+
+    _keys = {'deltaS', 'nobeta'}
+
+    def init_guess(self, hdiag, nstates=None):
+        if nstates is None:
+            nstates = self.nstates
+        n_init = min(nstates + 3, hdiag.size)
+        idx = np.argsort(hdiag)[:n_init]
+        x0 = np.zeros((n_init, hdiag.size))
+        x0[np.arange(n_init), idx] = 1.0
+        return x0
+
+    def kernel(self, x0=None, nstates=None):
+        cpu0 = (logger.process_clock(), logger.perf_counter())
+
+        self.check_sanity()
+        self.dump_flags()
+
+        if nstates is None:
+            nstates = self.nstates
+        else:
+            self.nstates = nstates
+        if self.deltaS == -1:
+            nstates += 1
+        log = logger.Logger(self.stdout, self.verbose)
+
+        def all_eigs(w, v, nroots, envs):
+            return w, v, np.arange(w.size)
+
+        if self.deltaS == 0:
+            vind, hdiag = self.gen_vind_sc()
+            precond = self.get_precond(hdiag)
+        elif self.deltaS == -1:
+            vind, hdiag = self.gen_vind_sfd()
+            precond = self.get_precond(hdiag)
+            csidx, osidx, vsidx = _orbital_indices(self)
+            nocc = len(csidx) + len(osidx)
+            nvir = len(osidx) + len(vsidx)
+        elif self.deltaS == 1:
+            vind, hdiag = self.gen_vind_sfu()
+            precond = self.get_precond(hdiag)
+            csidx, _, vsidx = _orbital_indices(self)
+            ncs = len(csidx)
+            nvs = len(vsidx)
+        else:
+            raise ValueError('deltaS should be -1, 0, or 1')
+
+        x0sym = None
+        if x0 is None:
+            x0 = self.init_guess(hdiag)
+
+        self.converged, self.e, x1 = lr_eigh(
+            vind,
+            x0,
+            precond,
+            tol_residual=self.conv_tol,
+            lindep=self.lindep,
+            nroots=nstates,
+            x0sym=x0sym,
+            pick=all_eigs,
+            max_cycle=self.max_cycle,
+            max_memory=self.max_memory,
+            verbose=log,
+        )
+
+        if self.deltaS == 0:
+            self.xy = [(xi, 0) for xi in x1]
+        elif self.deltaS == -1:
+            self.xy = [(xi.reshape(nocc, nvir), 0) for xi in x1]
+            mask = abs(self.e) > 1e-8
+            self.e = self.e[mask]
+            self.xy = [xy for xy, keep in zip(self.xy, mask) if keep]
+            self.nstates = len(self.e)
+        elif self.deltaS == 1:
+            self.xy = [(xi.reshape(ncs, nvs), 0) for xi in x1]
+
+        if self.chkfile:
+            lib.chkfile.save(self.chkfile, 'tddft/e', self.e)
+            lib.chkfile.save(self.chkfile, 'tddft/xy', self.xy)
+
+        log.timer('NTTDA', *cpu0)
+        self._finalize()
+        return self.e, self.xy
+
+    gen_vind_sfu = gen_vind_sfu
+    gen_vind_sc = gen_vind_sc
+    gen_vind_sfd = gen_vind_sfd
+
+
+def _guess_wfnsym_id(tdobj, x_sym, x):
+    possible_sym = np.asarray(x_sym)[np.abs(np.asarray(x)) > 1e-7]
+    wfnsym = symm.MULTI_IRREPS
+    ids = possible_sym[possible_sym != symm.MULTI_IRREPS]
+    if len(ids) > 0 and np.all(ids == ids[0]):
+        wfnsym = int(ids[0])
+    return wfnsym
+
+
+def _analyze_wfnsym(tdobj, x_sym, x):
+    wfnsym = _guess_wfnsym_id(tdobj, x_sym, x)
+    if wfnsym == symm.MULTI_IRREPS:
+        return wfnsym, '???'
+    return wfnsym, symm.irrep_id2name(tdobj.mol.groupname, wfnsym)
+
+
+def _sc_vector_slices(nc, no, nv):
+    co = nc * no
+    cv = nc * nv
+    oo = 1
+    ov = no * nv
+    p_co = 0
+    p_cv = p_co + co
+    p_oo = p_cv + cv
+    p_ov = p_oo + oo
+    p_cv0 = p_ov + ov
+    blocks = {
+        'CO(1)': slice(p_co, p_cv),
+        'CV(1)': slice(p_cv, p_oo),
+        'OO(1)': slice(p_oo, p_ov),
+        'OV(1)': slice(p_ov, p_cv0),
+    }
+    blocks['CV(0)'] = slice(p_cv0, p_cv0 + cv)
+    return blocks
+
+
+def _orbital_indices(tdobj):
+    mo_occ = np.asarray(tdobj._scf.mo_occ)
+    csidx = np.where(mo_occ == 2)[0]
+    osidx = np.where(mo_occ == 1)[0]
+    vsidx = np.where(mo_occ == 0)[0]
+    return csidx, osidx, vsidx
+
+
+def _log_state(log, tdobj, istate, e_ev, wfnsymid=None):
+    mol = tdobj.mol
+    mf = tdobj._scf
+    if wfnsymid is None:
+        log.note('Excited State %3d: %12.5f eV', istate + 1, e_ev)
+        return
+    orbsym = hf_symm.get_orbsym(mol, mf.mo_coeff)
+    refsym = hf_symm.get_wfnsym(mf, mf.mo_coeff, mf.mo_occ, orbsym)
+    refsym = int(np.asarray(refsym).ravel()[0])
+    if refsym == symm.MULTI_IRREPS or wfnsymid == symm.MULTI_IRREPS:
+        statesymlabel = '???'
+    else:
+        statesymid = symm.direct_prod(
+            np.array([int(wfnsymid)]), np.array([refsym]), mol.groupname,
+        ).ravel()[0]
+        if statesymid == symm.MULTI_IRREPS:
+            statesymlabel = '???'
+        else:
+            statesymlabel = symm.irrep_id2name(mol.groupname, int(statesymid))
+    log.note(
+        'Excited State %3d: %4s %12.5f eV',
+        istate + 1, statesymlabel, e_ev,
+    )
+
+
+def _analyze_sc(tdobj, verbose=None):
+    log = logger.new_logger(tdobj, verbose)
+    mol = tdobj.mol
+    mf = tdobj._scf
+    csidx, osidx, vsidx = _orbital_indices(tdobj)
+    nc = len(csidx)
+    no = len(osidx)
+    nv = len(vsidx)
+    slices = _sc_vector_slices(nc, no, nv)
+
+    if mol.symmetry:
+        orbsym = hf_symm.get_orbsym(mol, mf.mo_coeff)
+        x_sym = np.empty(slices['CV(0)'].stop, dtype=orbsym.dtype)
+        x_sym[slices['CO(1)']] = symm.direct_prod(
+            orbsym[csidx], orbsym[osidx], mol.groupname).ravel()
+        x_sym[slices['CV(1)']] = symm.direct_prod(
+            orbsym[csidx], orbsym[vsidx], mol.groupname).ravel()
+        x_sym[slices['OO(1)']] = 0
+        x_sym[slices['OV(1)']] = symm.direct_prod(
+            orbsym[osidx], orbsym[vsidx], mol.groupname).ravel()
+        x_sym[slices['CV(0)']] = symm.direct_prod(
+            orbsym[csidx], orbsym[vsidx], mol.groupname).ravel()
+    else:
+        x_sym = None
+
+    for i in range(tdobj.nstates):
+        x, y = tdobj.xy[i]
+        x = np.asarray(x).reshape(-1)
+        e_ev = np.asarray(tdobj.e[i]) * nist.HARTREE2EV
+
+        if x_sym is None:
+            _log_state(log, tdobj, i, e_ev)
+        else:
+            wfnsymid, _ = _analyze_wfnsym(tdobj, x_sym, x)
+            _log_state(log, tdobj, i, e_ev, wfnsymid)
+
+        if log.verbose >= logger.INFO:
+            x_co1 = x[slices['CO(1)']].reshape(nc, no)
+            x_cv1 = x[slices['CV(1)']].reshape(nc, nv)
+            x_oo1 = x[slices['OO(1)']]
+            x_ov1 = x[slices['OV(1)']].reshape(no, nv)
+            x_cv0 = x[slices['CV(0)']].reshape(nc, nv)
+            for c, o in zip(*np.where(np.abs(x_co1) > 0.1)):
+                log.info('    CO(1) %4d -> %4d %12.5f', csidx[c] + MO_BASE, osidx[o] + MO_BASE, x_co1[c, o])
+            for c, v in zip(*np.where(np.abs(x_cv1) > 0.1)):
+                log.info('    CV(1) %4d -> %4d %12.5f', csidx[c] + MO_BASE, vsidx[v] + MO_BASE, x_cv1[c, v])
+            if abs(x_oo1[0]) > 0.1:
+                log.info('    OO(1) %12.5f', x_oo1[0])
+            for o, v in zip(*np.where(np.abs(x_ov1) > 0.1)):
+                log.info('    OV(1) %4d -> %4d %12.5f', osidx[o] + MO_BASE, vsidx[v] + MO_BASE, x_ov1[o, v])
+            for c, v in zip(*np.where(np.abs(x_cv0) > 0.1)):
+                log.info('    CV(0) %4d -> %4d %12.5f', csidx[c] + MO_BASE, vsidx[v] + MO_BASE, x_cv0[c, v])
+    return tdobj
+
+
+def _analyze_sfd(tdobj, verbose=None):
+    log = logger.new_logger(tdobj, verbose)
+    mol = tdobj.mol
+    mf = tdobj._scf
+    csidx, osidx, vsidx = _orbital_indices(tdobj)
+    nc = len(csidx)
+    no = len(osidx)
+    nv = len(vsidx)
+    nocc = nc + no
+    nvir = no + nv
+
+    if mol.symmetry:
+        orbsym = hf_symm.get_orbsym(mol, mf.mo_coeff)
+        x_sym = np.empty((nocc, nvir), dtype=orbsym.dtype)
+        x_sym[:nc, :no] = symm.direct_prod(
+            orbsym[csidx], orbsym[osidx], mol.groupname)
+        x_sym[:nc, no:] = symm.direct_prod(
+            orbsym[csidx], orbsym[vsidx], mol.groupname)
+        x_sym[nc:, :no] = symm.direct_prod(
+            orbsym[osidx], orbsym[osidx], mol.groupname)
+        x_sym[nc:, no:] = symm.direct_prod(
+            orbsym[osidx], orbsym[vsidx], mol.groupname)
+    else:
+        x_sym = None
+
+    for i in range(tdobj.nstates):
+        x, y = tdobj.xy[i]
+        x = np.asarray(x).reshape(nocc, nvir)
+        e_ev = np.asarray(tdobj.e[i]) * nist.HARTREE2EV
+
+        x_co1 = x[:nc, :no]
+        x_cv1 = x[:nc, no:]
+        x_oo1 = x[nc:, :no]
+        x_ov1 = x[nc:, no:]
+
+        if x_sym is None:
+            _log_state(log, tdobj, i, e_ev)
+        else:
+            wfnsymid, _ = _analyze_wfnsym(tdobj, x_sym, x)
+            _log_state(log, tdobj, i, e_ev, wfnsymid)
+
+        if log.verbose >= logger.INFO:
+            for c, o in zip(*np.where(np.abs(x_co1) > 0.1)):
+                log.info('    CO(1) %4d -> %4d %12.5f', csidx[c] + MO_BASE, osidx[o] + MO_BASE, x_co1[c, o])
+            for c, v in zip(*np.where(np.abs(x_cv1) > 0.1)):
+                log.info('    CV(1) %4d -> %4d %12.5f', csidx[c] + MO_BASE, vsidx[v] + MO_BASE, x_cv1[c, v])
+            for o1, o2 in zip(*np.where(np.abs(x_oo1) > 0.1)):
+                log.info('    OO(1) %4d -> %4d %12.5f', osidx[o1] + MO_BASE, osidx[o2] + MO_BASE, x_oo1[o1, o2])
+            for o, v in zip(*np.where(np.abs(x_ov1) > 0.1)):
+                log.info('    OV(1) %4d -> %4d %12.5f', osidx[o] + MO_BASE, vsidx[v] + MO_BASE, x_ov1[o, v])
+    return tdobj
+
+
+def _analyze_sfu(tdobj, verbose=None):
+    log = logger.new_logger(tdobj, verbose)
+    mol = tdobj.mol
+    mf = tdobj._scf
+    csidx, osidx, vsidx = _orbital_indices(tdobj)
+    nc = len(csidx)
+    nv = len(vsidx)
+
+    if mol.symmetry:
+        orbsym = hf_symm.get_orbsym(mol, mf.mo_coeff)
+        x_sym = symm.direct_prod(orbsym[csidx], orbsym[vsidx],
+                                 mol.groupname)
+    else:
+        x_sym = None
+
+    nstates = min(tdobj.nstates, len(tdobj.xy))
+    for i in range(nstates):
+        x, y = tdobj.xy[i]
+        x_cv = np.asarray(x).reshape(nc, nv)
+        e_ev = np.asarray(tdobj.e[i]) * nist.HARTREE2EV
+
+        if x_sym is None:
+            _log_state(log, tdobj, i, e_ev)
+        else:
+            wfnsymid, _ = _analyze_wfnsym(tdobj, x_sym, x_cv)
+            _log_state(log, tdobj, i, e_ev, wfnsymid)
+
+        if log.verbose >= logger.INFO:
+            for c, v in zip(*np.where(np.abs(x_cv) > 0.1)):
+                log.info('    CV(1) %4d -> %4d %12.5f',
+                         csidx[c] + MO_BASE, vsidx[v] + MO_BASE, x_cv[c, v])
+    return tdobj
+
+
+def analyze(tdobj, verbose=None):
+    if tdobj.deltaS == 0:
+        return _analyze_sc(tdobj, verbose)
+    if tdobj.deltaS == -1:
+        return _analyze_sfd(tdobj, verbose)
+    if tdobj.deltaS == 1:
+        return _analyze_sfu(tdobj, verbose)
+    raise ValueError('deltaS should be -1, 0, or 1')
+
+
+NTTDA.analyze = analyze
+
+dft.roks.ROKS.NTTDA = lib.class_as_method(NTTDA)
+dft.rks_symm.SymAdaptedROKS.NTTDA = lib.class_as_method(NTTDA)

--- a/src/nest/nttda/tests/test_nttda.py
+++ b/src/nest/nttda/tests/test_nttda.py
@@ -1,0 +1,117 @@
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from pyscf import gto
+from nest import nttda
+
+
+class KnownValues(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        mol = gto.Mole()
+        mol.verbose = 0
+        mol.output = '/dev/null'
+        mol.atom = """
+        O                  0.64372820    0.14077399   -0.04477253
+        O                 -0.64862595   -0.12779073   -0.05445498
+        H                  1.16027512   -0.65947800    0.36730132
+        H                 -1.12109306    0.55561188    0.42651873
+        """
+        mol.charge = 0
+        mol.spin = 2
+        mol.basis = '631g'
+        cls.mol = mol.build()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mol.stdout.close()
+
+    def test_hf_nttda(self):
+        mf = self.mol.ROKS(xc='HF').run()
+
+        ref = np.array([0.26373033968267973, 0.32114587049263738])
+        td = mf.NTTDA().set(nstates=2, deltaS=1, nobeta=True).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, delta=1e-6)
+
+        ref = np.array([-0.25588162251385815, 0.03179164805915535])
+        td = mf.NTTDA().set(nstates=2, deltaS=-1, nobeta=False).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, delta=1e-6)
+
+        ref = np.array([-0.021227306082554027, 0.03681224565830669])
+        td = mf.NTTDA().set(nstates=2, deltaS=0, nobeta=False).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, delta=1e-6)
+
+    def test_svwn_nttda(self):
+        mf = self.mol.ROKS(xc='SVWN').run()
+
+        ref = np.array([-0.21136285952298853, 0.022829192982022128])
+        td = mf.NTTDA().set(nstates=2, deltaS=-1, nobeta=True).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, delta=1e-6)
+
+        ref = np.array([-0.0014224229333087768, 0.029907227771976085])
+        td = mf.NTTDA().set(nstates=2, deltaS=0, nobeta=True).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, delta=1e-6)
+
+        ref = np.array([0.2621305574444208, 0.3146577468311684])
+        td = mf.NTTDA().set(nstates=2, deltaS=1, nobeta=False).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, delta=1e-6)
+
+    def test_m062x_nttda(self):
+        mf = self.mol.ROKS(xc='M062X').run()
+
+        ref = np.array([-0.24666086824597583, 0.015820053409613927])
+        td = mf.NTTDA().set(nstates=2, deltaS=-1, nobeta=True).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, delta=1e-6)
+
+        ref = np.array([-0.008184446338165025, 0.025150738879015422])
+        td = mf.NTTDA().set(nstates=2, deltaS=0, nobeta=False).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, delta=1e-6)
+
+        ref = np.array([0.26880002289621757, 0.3280851476633962])
+        td = mf.NTTDA().set(nstates=2, deltaS=1, nobeta=False).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, delta=1e-6)
+
+    def test_cam_b3lyp_nttda(self):
+        mf = self.mol.ROKS(xc='CAM-B3LYP').run()
+
+        ref = np.array([-0.0044893465927124268, 0.035037117269294718])
+        td = mf.NTTDA().set(nstates=2, deltaS=0, nobeta=True).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, delta=1e-6)
+
+        ref = np.array([0.27155932081326395, 0.32184531828332463])
+        td = mf.NTTDA().set(nstates=2, deltaS=1, nobeta=True).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, delta=1e-6)
+
+        ref = np.array([-0.22362676199942616, 0.02217598445976246])
+        td = mf.NTTDA().set(nstates=2, deltaS=-1, nobeta=False).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, delta=1e-6)
+
+
+if __name__ == '__main__':
+    print('Full tests for noncollinear tensor TDA based on ROKS reference')
+    unittest.main()

--- a/src/nest/sftda/__init__.py
+++ b/src/nest/sftda/__init__.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# Copyright 2014-2024 The PySCF Developers. All Rights Reserved.
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyscf import scf, dft
+from nest.sftda import uhf_sf
+
+
+def TDA_SF(mf):
+    mf = mf.remove_soscf()
+    if isinstance(mf, scf.rohf.ROHF) or isinstance(mf, scf.hf_symm.SymAdaptedROHF):
+        if isinstance(mf, dft.roks.ROKS) or isinstance(mf, dft.rks_symm.SymAdaptedROKS):
+            mf = mf.to_uks()
+        else:
+            mf = mf.to_uhf()
+    return mf.TDA_SF()
+
+
+def TDDFT_SF(mf):
+    mf = mf.remove_soscf()
+    if isinstance(mf, scf.rohf.ROHF) or isinstance(mf, scf.hf_symm.SymAdaptedROHF):
+        if isinstance(mf, dft.roks.ROKS) or isinstance(mf, dft.rks_symm.SymAdaptedROKS):
+            mf = mf.to_uks()
+        else:
+            mf = mf.to_uhf()
+    return mf.TDDFT_SF()
+
+
+SFTDA = TDA_SF
+SFTDDFT = TDDFT_SF
+
+__all__ = [
+    "SFTDA",
+    "SFTDDFT",
+    "TDA_SF",
+    "TDDFT_SF",
+    "uhf_sf",
+]

--- a/src/nest/sftda/_lr_eig.py
+++ b/src/nest/sftda/_lr_eig.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python
+# Copyright 2014-2024 The PySCF Developers. All Rights Reserved.
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import numpy as np
+import scipy
+from pyscf.lib import logger
+from pyscf.lib.parameters import MAX_MEMORY
+from pyscf.lib.linalg_helper import _sort_elast
+from pyscf.tdscf._lr_eig import _qr, MAX_SPACE_INC
+
+
+def davidson_nosym1(aop, x0, precond, tol=1e-12, max_cycle=50, lindep=1e-12, callback=None,
+                    max_space=20,
+                    max_memory=MAX_MEMORY, nroots=1, pick=None, verbose=logger.WARN):
+    '''
+    slightly modified from pyscf.lib.linalg.davidson_nosym1 with vectorization support
+    '''
+    def _qr(xs, lindep=1e-14):
+        q, r = np.linalg.qr(xs.T, mode='reduced')
+        r_diag = np.abs(np.diag(r))
+        mask = r_diag > lindep
+        qs = q.T[mask]
+        return qs, np.where(mask)[0]
+
+    assert callable(pick)
+    assert callable(precond)
+
+    if isinstance(verbose, logger.Logger):
+        log = verbose
+    else:
+        log = logger.Logger(sys.stdout, verbose)
+
+    toloose = tol ** 0.5
+    log.debug1('tol %g  toloose %g', tol, toloose)
+
+    if isinstance(x0, np.ndarray) and x0.ndim == 1:
+        x0 = x0[None, :]
+    x0 = np.asarray(x0)
+    x0_size = x0.shape[1]
+
+    if MAX_SPACE_INC is None:
+        space_inc = nroots
+    else:
+        space_inc = min(nroots, min(MAX_SPACE_INC, x0_size//2))
+    max_space = int(max_memory*1e6/8/x0_size / 2 - nroots - space_inc)
+    if max_space < nroots * 4 < x0_size:
+        log.warn('Not enough memory to store trial space in _lr_eig.eigh')
+    max_space = max(max_space, nroots * 4)
+    max_space = min(max_space, x0_size)
+    log.debug(f'Set max_space {max_space}, space_inc {space_inc}')
+
+    xs = np.empty((max_space, x0_size), dtype=x0.dtype)
+    ax = np.empty((max_space, x0_size), dtype=x0.dtype)
+    heff = np.empty((max_space, max_space), dtype=x0.dtype)
+    fresh_start = True
+    space = 0
+    e = None
+    v = None
+    conv = np.zeros(nroots, dtype=bool)
+    conv_last = np.zeros(nroots, dtype=bool)
+
+    for icyc in range(max_cycle):
+        if fresh_start:
+            xs = np.empty_like(xs)
+            ax = np.empty_like(ax)
+            space = 0
+            x0len = len(x0)
+            xt, _ = _qr(x0, lindep)
+            if len(xt) != x0len:
+                log.warn('QR decomposition removed %d vectors. '
+                            'Check to see if `pick` function :%s: is providing linear dependent '
+                            'vectors' % (x0len - len(xt), pick.__name__))
+        elif len(xt) > 1:
+            xt, _ = _qr(xt, lindep)
+        if icyc != 0:
+            xt = xt[:space_inc]
+
+        add = xt.shape[0]
+        axt = aop(xt)
+        xs[space: space+add] = xt
+        ax[space: space+add] = axt
+        space_old = space
+        space += add
+        if fresh_start:
+            heff.fill(0)
+        heff[:space_old, space_old:space] = xs[:space_old].conj().dot(ax[space_old:space].T)
+        heff[space_old:space, :space_old] = xs[space_old:space].conj().dot(ax[:space_old].T)
+        heff[space_old:space, space_old:space] = xs[space_old:space].conj().dot(ax[space_old:space].T)
+        xt = axt = None
+
+        elast = e
+        vlast = v
+        conv_last = conv
+
+        w_npu, v_npu = scipy.linalg.eig(heff[:space,:space])
+        w, v = np.asarray(w_npu), np.asarray(v_npu)
+        w, v, idx = pick(w, v, nroots, locals())
+        if len(w) == 0:
+            raise RuntimeError('Not enough eigenvalues')
+
+        e = w[:nroots]
+        v = v[:,:nroots]
+        if not fresh_start:
+            elast, conv_last = _sort_elast(elast, conv_last, vlast, v, log)
+
+        if elast is None:
+            de = e
+        elif elast.size != e.size:
+            log.debug('Number of roots different from the previous step (%d,%d)',
+                      e.size, elast.size)
+            de = e
+        else:
+            de = e - elast
+
+        x0 = v.T.dot(xs[:space])
+        ax0 = v.T.dot(ax[:space])
+
+        xt = ax0[:nroots] - e[:, None] * x0[:nroots]
+        ax0 = None
+
+        dx_norm = np.linalg.norm(xt, axis=1)
+        conv =  (abs(de) < tol) & (dx_norm < toloose)
+        for k, ek in enumerate(e):
+            if conv[k] and not conv_last[k]:
+                log.debug('root %d converged  |r|= %4.3g  e= %s  max|de|= %4.3g',
+                          k, dx_norm[k], ek, de[k])
+        ax0 = None
+        max_dx_norm = max(dx_norm)
+        max_de = max(abs(de))
+        if all(conv):
+            log.debug('converged %d %d  |r|= %4.3g  e= %s  max|de|= %4.3g',
+                      icyc, len(xs), max_dx_norm, e, max_de)
+            break
+
+        mask = (~conv) & (dx_norm**2 > lindep)
+        xt = precond(xt[mask], e[0], x0[mask])
+        valid_xs = xs[:space]
+        for _ in range(2):
+            xt -= np.dot(np.dot(xt, valid_xs.T.conj()), valid_xs)
+        xt_norm = np.linalg.norm(xt, axis=1)
+        keep_mask = (xt_norm**2 > lindep)
+        xt = xt[keep_mask]
+        xt_norm = xt_norm[keep_mask]
+
+        if len(xt)==0:
+            log.debug('Linear dependency in trial subspace. |r| for each state %s',
+                      dx_norm)
+            conv = dx_norm < toloose
+            break
+        log.debug('davidson %d %d  |r|= %4.3g  e= %s  max|de|= %4.3g  lindep= %4.3g',
+                  icyc, space, max_dx_norm, e, max_de, np.linalg.norm(xt, axis=1).min())
+
+        xt /= xt_norm[:, None]
+
+        fresh_start = space+len(xt) > max_space
+        if callable(callback):
+            callback(locals())
+
+    return conv, e, x0
+
+
+def eigh(aop, x0, precond, tol_residual=1e-5, lindep=1e-12, nroots=1,
+         x0sym=None, pick=None, max_cycle=50, max_memory=MAX_MEMORY,
+         verbose=logger.WARN):
+    '''
+    slightly modified from pyscf.tdscf._lr_eig.eigh
+    '''
+
+    assert callable(pick)
+    assert callable(precond)
+
+    log = logger.new_logger(verbose)
+
+    if isinstance(x0, np.ndarray) and x0.ndim == 1:
+        x0 = x0[None,:]
+    x0 = np.asarray(x0)
+
+    x0_size = x0.shape[1]
+    if MAX_SPACE_INC is None:
+        space_inc = nroots
+    else:
+        # Adding too many trial bases in each iteration may cause larger errors
+        space_inc = min(nroots, min(MAX_SPACE_INC, x0_size//2))
+
+    max_space = int(max_memory*1e6/8/x0_size / 2 - nroots - space_inc)
+    if max_space < nroots * 4 < x0_size:
+        log.warn('Not enough memory to store trial space in _lr_eig.eigh')
+    max_space = max(max_space, nroots * 4)
+    max_space = min(max_space, x0_size)
+    log.debug(f'Set max_space {max_space}, space_inc {space_inc}')
+
+    xs = np.zeros((0, x0_size))
+    ax = np.zeros((0, x0_size))
+    e = w = v = None
+    conv_last = conv = np.zeros(nroots, dtype=bool)
+    xt = x0
+
+    if x0sym is not None:
+        xt_ir = np.asarray(x0sym)
+        xs_ir = np.array([], dtype=xt_ir.dtype)
+
+    for icyc in range(max_cycle):
+        xt, xt_idx = _qr(xt, lindep)
+        # Generate at most space_inc trial vectors
+        if icyc != 0:
+            xt = xt[:space_inc]
+            xt_idx = xt_idx[:space_inc]
+
+        row0 = len(xs)
+        axt = aop(xt)
+        xs = np.vstack([xs, xt])
+        ax = np.vstack([ax, axt])
+        if x0sym is not None:
+            xs_ir = np.hstack([xs_ir, xt_ir[xt_idx]])
+
+        # Compute heff = xs.conj().dot(ax.T)
+        if w is None:
+            heff = xs.conj().dot(ax.T)
+        else:
+            hsub = xt.conj().dot(ax.T)
+            heff = np.block([[np.diag(w), hsub[:,:row0].conj().T],
+                             [hsub[:,:row0], hsub[:,row0:]]])
+
+        if x0sym is None:
+            w, v = scipy.linalg.eigh(heff)
+        else:
+            # Diagonalize within eash symmetry sectors
+            row1 = len(xs)
+            w = np.empty(row1)
+            v = np.zeros((row1, row1))
+            v_ir = []
+            i1 = 0
+            for ir in set(xs_ir):
+                idx = np.where(xs_ir == ir)[0]
+                i0, i1 = i1, i1 + idx.size
+                w_sub, v_sub = scipy.linalg.eigh(heff[idx[:,None],idx])
+                w[i0:i1] = w_sub
+                v[idx,i0:i1] = v_sub
+                v_ir.append([ir] * idx.size)
+            w_idx = np.argsort(w)
+            w = w[w_idx]
+            v = v[:,w_idx]
+            xs_ir = np.hstack(v_ir)[w_idx]
+
+        w, v, idx = pick(w, v, nroots, locals())
+        if x0sym is not None:
+            xs_ir = xs_ir[idx]
+        if len(w) == 0:
+            raise RuntimeError('Not enough eigenvalues')
+
+        e, elast = w[:nroots], e
+        if elast is None:
+            de = e
+        elif elast.size != e.size:
+            log.debug('Number of roots different from the previous step (%d,%d)',
+                      e.size, elast.size)
+            de = e
+        else:
+            # mapping to previous eigenvectors
+            vlast = np.eye(nroots)
+            elast, conv_last = _sort_elast(elast, conv, vlast,
+                                           v[:nroots,:nroots], log)
+            de = e - elast
+
+        xs = v.T.dot(xs)
+        ax = v.T.dot(ax)
+        if len(xs) * 2 > max_space:
+            row0 = max(nroots, max_space-space_inc)
+            xs = xs[:row0]
+            ax = ax[:row0]
+            w = w[:row0]
+            if x0sym is not None:
+                xs_ir = xs_ir[:row0]
+
+        t_size = max(nroots, max_space-len(xs))
+        xt = -w[:t_size,None] * xs[:t_size]
+        xt += ax[:t_size]
+        if x0sym is not None:
+            xt_ir = xs_ir[:t_size]
+
+        dx_norm = np.linalg.norm(xt, axis=1)
+        max_dx_norm = max(dx_norm[:nroots])
+        conv = dx_norm[:nroots] < tol_residual
+        for k, ek in enumerate(e[:nroots]):
+            if conv[k] and not conv_last[k]:
+                log.debug('root %d converged  |r|= %4.3g  e= %s  max|de|= %4.3g',
+                          k, dx_norm[k], ek, de[k])
+            else:
+                log.debug1('root %d  |r|= %4.3g  e= %s  max|de|= %4.3g',
+                          k, dx_norm[k], ek, de[k])
+        ide = np.argmax(abs(de))
+        if all(conv):
+            log.debug('converged %d %d  |r|= %4.3g  e= %s  max|de|= %4.3g',
+                      icyc, len(xs), max_dx_norm, e, de[ide])
+            break
+
+        # remove subspace linear dependency
+        for k, xk in enumerate(xt):
+            if dx_norm[k] > tol_residual:
+                xt[k] = precond(xk, e[0])
+        xt -= xs.conj().dot(xt.T).T.dot(xs)
+        xt_norm = np.linalg.norm(xt, axis=1)
+
+        remaining = []
+        for k, xk in enumerate(xt):
+            if dx_norm[k] > tol_residual and xt_norm[k]**2 > lindep:
+                xt[k] /= xt_norm[k]
+                remaining.append(k)
+        if len(remaining) == 0:
+            log.debug(f'Linear dependency in trial subspace. |r| for each state {dx_norm}')
+            break
+
+        xt = xt[remaining]
+        log.debug1('Generate %d trial vectors. Drop %d vectors',
+                   len(xt), dx_norm.size - len(xt))
+
+        if x0sym is not None:
+            xt_ir = xt_ir[remaining]
+        norm_min = xt_norm[remaining].min()
+        log.debug('davidson %d %d |r|= %4.3g  e= %s  max|de|= %4.3g  lindep= %4.3g',
+                  icyc, len(xs), max_dx_norm, e, de[ide], norm_min)
+
+    x0 = xs[:nroots]
+    # Check whether the solver finds enough eigenvectors.
+    if len(x0) < min(x0_size, nroots):
+        log.warn(f'Not enough eigenvectors (len(x0)={len(x0)}, nroots={nroots})')
+
+    return conv, e, x0

--- a/src/nest/sftda/numint2c_sftd.py
+++ b/src/nest/sftda/numint2c_sftd.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+# Copyright 2014-2024 The PySCF Developers. All Rights Reserved.
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file can be merged into pyscf.dft.numint2c.py
+
+MGGA_DENSITY_LAPL = False # just copy from pyscf.dft.numint2c.py
+
+import functools
+import numpy as np
+from pyscf import lib
+from pyscf.dft import numint, xc_deriv
+
+# This function is copied from pyscf.dft.numint2c.py
+def __mcfun_fn_eval_xc(ni, xc_code, xctype, rho, deriv):
+    evfk = ni.eval_xc_eff(xc_code, rho, deriv=deriv, xctype=xctype)
+    for order in range(1, deriv+1):
+        if evfk[order] is not None:
+            evfk[order] = xc_deriv.ud2ts(evfk[order])
+    return evfk
+
+# This function can be merged with pyscf.dft.numint2c.mcfun_eval_xc_adapter()
+# This function should be a class function in the Numint2c class.
+def mcfun_eval_xc_adapter_sf(ni, xc_code):
+    '''Wrapper to generate the eval_xc function required by mcfun
+
+    Kwargs:
+        dim: int
+            eval_xc_eff_sf is for mc collinear sf tddft/ tda case.add().
+    '''
+
+    try:
+        import mcfun
+    except ImportError:
+        raise ImportError('This feature requires mcfun library.\n'
+                          'Try install mcfun with `pip install mcfun`')
+
+    xctype = ni._xc_type(xc_code)
+    fn_eval_xc = functools.partial(__mcfun_fn_eval_xc, ni, xc_code, xctype)
+    nproc = lib.num_threads()
+
+    def eval_xc_eff(xc_code, rho, deriv, omega=None, xctype=None,
+                verbose=None):
+        return mcfun.eval_xc_eff_sf(
+            fn_eval_xc, rho, deriv,
+            collinear_samples=ni.collinear_samples, workers=nproc)
+    return eval_xc_eff
+
+# This function should be a class function in the Numint2c class.
+def cache_xc_kernel_sf(self, mol, grids, xc_code, mo_coeff, mo_occ, deriv=2,
+                       spin=1, max_memory=2000):
+    '''Compute the fxc_sf, which can be used in SF-TDDFT/TDA
+    '''
+    xctype = self._xc_type(xc_code)
+    if xctype == 'GGA':
+        ao_deriv = 1
+    elif xctype == 'MGGA':
+        ao_deriv = 2 if MGGA_DENSITY_LAPL else 1
+    else:
+        ao_deriv = 0
+    with_lapl = MGGA_DENSITY_LAPL
+
+    assert mo_coeff[0].ndim == 2
+    assert spin == 1
+
+    nao = mo_coeff[0].shape[0]
+    rhoa = []
+    rhob = []
+
+    ni = numint.NumInt()
+    for ao, mask, weight, coords \
+            in self.block_loop(mol, grids, nao, ao_deriv, max_memory=max_memory):
+        rhoa.append(ni.eval_rho2(mol, ao, mo_coeff[0], mo_occ[0], mask, xctype, with_lapl))
+        rhob.append(ni.eval_rho2(mol, ao, mo_coeff[1], mo_occ[1], mask, xctype, with_lapl))
+    rho_ab = (np.hstack(rhoa), np.hstack(rhob))
+    rho_ab = np.asarray(rho_ab)
+    rho_tmz = np.zeros_like(rho_ab)
+    rho_tmz[0] += rho_ab[0]+rho_ab[1]
+    rho_tmz[1] += rho_ab[0]-rho_ab[1]
+    eval_xc = mcfun_eval_xc_adapter_sf(self,xc_code)
+    fxc_sf = eval_xc(xc_code, rho_tmz, deriv=deriv, xctype=xctype)
+    return fxc_sf

--- a/src/nest/sftda/scf_genrep_sftd.py
+++ b/src/nest/sftda/scf_genrep_sftd.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# Copyright 2014-2024 The PySCF Developers. All Rights Reserved.
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file can be merged into pyscf.scf._response_functions.py
+
+import numpy as np
+from pyscf import lib
+from pyscf.lib import logger
+from pyscf.scf import uhf
+from pyscf.dft import KohnShamDFT, numint, numint2c
+
+# import fcuntion
+from nest.sftda.numint2c_sftd import cache_xc_kernel_sf
+
+def gen_uhf_response_sf(
+    mf,
+    mo_coeff=None,
+    mo_occ=None,
+    hermi=0,
+    collinear="mcol",
+    collinear_samples=200,
+    max_memory=None,
+):
+    '''
+    Generate a function to compute the product of Spin-flip UKS response function
+    and UKS density matrices.
+    '''
+    assert isinstance(mf, (uhf.UHF))
+    if mo_coeff is None:
+        mo_coeff = mf.mo_coeff
+    if mo_occ is None:
+        mo_occ = mf.mo_occ
+    mol = mf.mol
+
+    if isinstance(mf, KohnShamDFT):
+        if collinear not in ("col", "mcol"):
+            raise ValueError("collinear must be 'col' or 'mcol'")
+
+        ni = numint2c.NumInt2C()
+        ni.collinear = collinear
+        ni.collinear_samples = collinear_samples
+        ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
+
+        if mf.nlc or ni.libxc.is_nlc(mf.xc):
+            logger.warn(mf, 'NLC functional found in DFT object. Its contribution is '
+            'not included in the TDDFT response function.')
+        omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
+        hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+
+        if collinear == "mcol":
+            fxc = 2.0 * cache_xc_kernel_sf(ni, mol, mf.grids, mf.xc, mo_coeff, mo_occ, deriv=2, spin=1)[2]
+
+        dm0 = None
+
+        if max_memory is None:
+            max_memory = mf.max_memory
+        max_memory = max_memory * 0.8 - lib.current_memory()[0]
+
+        def vind(dm1):
+            if collinear == "col":
+                v1 = np.zeros_like(dm1)
+            else:
+                in2 = numint.NumInt()
+                v1 = in2.nr_rks_fxc(mol, mf.grids, mf.xc, dm0, dm1, 0, hermi,
+                                    None, None, fxc, max_memory=max_memory)
+            if hybrid:
+                # j = 0 in spin flip part.
+                if omega == 0:
+                    vk = mf.get_k(mol, dm1, hermi) * hyb
+                elif alpha == 0: # LR=0, only SR exchange
+                    vk = mf.get_k(mol, dm1, hermi, omega=-omega) * hyb
+                elif hyb == 0: # SR=0, only LR exchange
+                    vk = mf.get_k(mol, dm1, hermi, omega=omega) * alpha
+                else: # SR and LR exchange with different ratios
+                    vk = mf.get_k(mol, dm1, hermi) * hyb
+                    vk += mf.get_k(mol, dm1, hermi, omega=omega) * (alpha-hyb)
+                v1 -= vk
+            return v1
+        return vind
+    else: # HF
+        def vind(dm1):
+            vk = mf.get_k(mol, dm1, hermi)
+            return -vk
+        return vind

--- a/src/nest/sftda/tests/test_sftda.py
+++ b/src/nest/sftda/tests/test_sftda.py
@@ -1,0 +1,181 @@
+# Copyright 2021-2024 The PySCF Developers. All Rights Reserved.
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from pyscf import gto
+from nest import sftda
+
+def diagonalize_tda(mf, extype=1, collinear="mcol", collinear_samples=50, nstates=5):
+    a, b = sftda.uhf_sf.get_ab_sf(mf, collinear=collinear, collinear_samples=collinear_samples)
+    A_baba, A_abab = a
+    B_baab, B_abba = b
+    n_occ_a, n_virt_b = A_abab.shape[0], A_abab.shape[1]
+    n_occ_b, n_virt_a = B_abba.shape[2], B_abba.shape[3]
+    A_abab_2d = A_abab.reshape((n_occ_a*n_virt_b, n_occ_a*n_virt_b), order='C')
+    B_abba_2d = B_abba.reshape((n_occ_a*n_virt_b, n_occ_b*n_virt_a), order='C')
+    B_baab_2d = B_baab.reshape((n_occ_b*n_virt_a, n_occ_a*n_virt_b), order='C')
+    A_baba_2d = A_baba.reshape((n_occ_b*n_virt_a, n_occ_b*n_virt_a), order='C')
+    Casida_matrix = np.block([[ A_abab_2d, np.zeros_like(B_abba_2d)],
+                              [np.zeros_like(-B_baab_2d), -A_baba_2d]])
+    eigenvals, eigenvecs = np.linalg.eig(Casida_matrix)
+    idx = eigenvals.real.argsort()
+    eigenvals = eigenvals[idx]
+    eigenvecs = eigenvecs[:, idx]
+    norms = np.linalg.norm(eigenvecs[:n_occ_a*n_virt_b], axis=0)**2
+    norms -= np.linalg.norm(eigenvecs[n_occ_a*n_virt_b:], axis=0)**2
+    if extype == 1:
+        mask = norms > 1e-3
+        valid_e = eigenvals[mask].real
+    else:
+        mask = norms < -1e-3
+        valid_e = eigenvals[mask].real
+        valid_e = -valid_e
+    lowest_e = np.sort(valid_e)[:nstates]
+    return lowest_e
+
+class KnownValues(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        mol = gto.Mole()
+        mol.verbose = 0
+        mol.output = '/dev/null'
+        mol.atom = '''
+        O     0.   0.       0.
+        H     0.   -0.757   0.587
+        H     0.   0.757    0.587'''
+        mol.spin = 2
+        mol.basis = '631g'
+        cls.mol = mol.build()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mol.stdout.close()
+
+    def test_hf_tda(self):
+        mf = self.mol.UKS(xc='HF').run()
+        ref = np.array([0.4664408971, 0.5575560788])
+        td = mf.TDA_SF().set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2157451986,  0.0027042225])
+        td = mf.TDA_SF().set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_mcol_lda_tda(self):
+        mf = self.mol.UKS(xc='SVWN').run()
+        ref = np.array([0.4502240188, 0.5791758572])
+        td = mf.TDA_SF().set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.3264298143,  0.0003751741])
+        td = mf.TDA_SF().set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_mcol_b3lyp_tda(self):
+        mf = self.mol.UKS(xc='B3LYP').run()
+        ref = np.array([0.4594126525, 0.5779958668])
+        td = mf.TDA_SF().set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2962917674,  0.0006700177])
+        td = mf.TDA_SF().set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_col_b3lyp_tda(self):
+        mf = self.mol.UKS(xc='B3LYP').run()
+        ref = np.array([0.4737123152, 0.6066070401])
+        td = mf.TDA_SF().set(extype=0, collinear="col", collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=0, collinear="col", collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2851971087,  0.0428751344])
+        td = mf.TDA_SF().set(extype=1, collinear="col", collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=1, collinear="col", collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_mcol_tpss_tda(self):
+        mf = self.mol.UKS(xc='TPSS').run()
+        ref = np.array([0.449865372, 0.5707190159])
+        td = mf.TDA_SF().set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2869994089,  0.0006366278])
+        td = mf.TDA_SF().set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_mcol_cam_tda(self):
+        mf = self.mol.UKS(xc='CAM-B3LYP').run()
+        ref = np.array([0.4617250119, 0.5771124927])
+        td = mf.TDA_SF().set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2975653443,  0.0006832701])
+        td = mf.TDA_SF().set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_col_cam_tda(self):
+        mf = self.mol.UKS(xc='CAM-B3LYP').run()
+        ref = np.array([0.4754934156, 0.6049670138])
+        td = mf.TDA_SF().set(extype=0, collinear="col", collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=0, collinear="col", collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2873952196,  0.0303549298])
+        td = mf.TDA_SF().set(extype=1, collinear="col", collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=1, collinear="col", collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+if __name__ == "__main__":
+    print("Full Tests for spin-flip-TDA with multicollinear functionals and collinear functionals")
+    unittest.main()

--- a/src/nest/sftda/tests/test_sftda_roks.py
+++ b/src/nest/sftda/tests/test_sftda_roks.py
@@ -1,0 +1,181 @@
+# Copyright 2021-2024 The PySCF Developers. All Rights Reserved.
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from pyscf import gto
+from nest import sftda
+
+def diagonalize_tda(mf, extype=1, collinear="mcol", collinear_samples=50, nstates=5):
+    a, b = sftda.uhf_sf.get_ab_sf(mf, collinear=collinear, collinear_samples=collinear_samples)
+    A_baba, A_abab = a
+    B_baab, B_abba = b
+    n_occ_a, n_virt_b = A_abab.shape[0], A_abab.shape[1]
+    n_occ_b, n_virt_a = B_abba.shape[2], B_abba.shape[3]
+    A_abab_2d = A_abab.reshape((n_occ_a*n_virt_b, n_occ_a*n_virt_b), order='C')
+    B_abba_2d = B_abba.reshape((n_occ_a*n_virt_b, n_occ_b*n_virt_a), order='C')
+    B_baab_2d = B_baab.reshape((n_occ_b*n_virt_a, n_occ_a*n_virt_b), order='C')
+    A_baba_2d = A_baba.reshape((n_occ_b*n_virt_a, n_occ_b*n_virt_a), order='C')
+    Casida_matrix = np.block([[ A_abab_2d, np.zeros_like(B_abba_2d)],
+                              [np.zeros_like(-B_baab_2d), -A_baba_2d]])
+    eigenvals, eigenvecs = np.linalg.eig(Casida_matrix)
+    idx = eigenvals.real.argsort()
+    eigenvals = eigenvals[idx]
+    eigenvecs = eigenvecs[:, idx]
+    norms = np.linalg.norm(eigenvecs[:n_occ_a*n_virt_b], axis=0)**2
+    norms -= np.linalg.norm(eigenvecs[n_occ_a*n_virt_b:], axis=0)**2
+    if extype == 1:
+        mask = norms > 1e-3
+        valid_e = eigenvals[mask].real
+    else:
+        mask = norms < -1e-3
+        valid_e = eigenvals[mask].real
+        valid_e = -valid_e
+    lowest_e = np.sort(valid_e)[:nstates]
+    return lowest_e
+
+class KnownValues(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        mol = gto.Mole()
+        mol.verbose = 0
+        mol.output = '/dev/null'
+        mol.atom = '''
+        O     0.   0.       0.
+        H     0.   -0.757   0.587
+        H     0.   0.757    0.587'''
+        mol.spin = 2
+        mol.basis = '631g'
+        cls.mol = mol.build()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mol.stdout.close()
+
+    def test_hf_tda(self):
+        mf = self.mol.ROKS(xc='HF').run()
+        ref = np.array([0.4728164461, 0.5570168495])
+        td = sftda.TDA_SF(mf).set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2204522712, -0.0023966488])
+        td = sftda.TDA_SF(mf).set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_mcol_lda_tda(self):
+        mf = self.mol.ROKS(xc='SVWN').run()
+        ref = np.array([0.4508285718, 0.5792438533])
+        td = sftda.TDA_SF(mf).set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.3271863485, -0.000335489 ])
+        td = sftda.TDA_SF(mf).set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_mcol_b3lyp_tda(self):
+        mf = self.mol.ROKS(xc='B3LYP').run()
+        ref = np.array([0.4606522787, 0.5780790823])
+        td = sftda.TDA_SF(mf).set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2976172461, -0.000605713 ])
+        td = sftda.TDA_SF(mf).set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_col_b3lyp_tda(self):
+        mf = self.mol.ROKS(xc='B3LYP').run()
+        ref = np.array([0.4749475052, 0.6067006254])
+        td = sftda.TDA_SF(mf).set(extype=0, collinear="col", collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=0, collinear="col", collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2865096495,  0.0416989745])
+        td = sftda.TDA_SF(mf).set(extype=1, collinear="col", collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=1, collinear="col", collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_mcol_tpss_tda(self):
+        mf = self.mol.ROKS(xc='TPSS').run()
+        ref = np.array([0.4506804512, 0.5704060695])
+        td = sftda.TDA_SF(mf).set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2883457218, -0.0005819225])
+        td = sftda.TDA_SF(mf).set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_mcol_cam_tda(self):
+        mf = self.mol.ROKS(xc='CAM-B3LYP').run()
+        ref = np.array([0.463106907 , 0.5771522483])
+        td = sftda.TDA_SF(mf).set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2989172623, -0.0006272555])
+        td = sftda.TDA_SF(mf).set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_col_cam_tda(self):
+        mf = self.mol.ROKS(xc='CAM-B3LYP').run()
+        ref = np.array([0.4768390356, 0.6049192733])
+        td = sftda.TDA_SF(mf).set(extype=0, collinear="col", collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=0, collinear="col", collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2887349087,  0.0291502911])
+        td = sftda.TDA_SF(mf).set(extype=1, collinear="col", collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tda(mf, extype=1, collinear="col", collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+if __name__ == "__main__":
+    print("Full Tests for spin-flip-TDA based on ROKS reference")
+    unittest.main()

--- a/src/nest/sftda/tests/test_sftddft.py
+++ b/src/nest/sftda/tests/test_sftddft.py
@@ -1,0 +1,181 @@
+# Copyright 2021-2024 The PySCF Developers. All Rights Reserved.
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from pyscf import gto
+from nest import sftda
+
+def diagonalize_tddft(mf, extype=1, collinear="mcol", collinear_samples=50, nstates=5):
+    a, b = sftda.uhf_sf.get_ab_sf(mf, collinear=collinear, collinear_samples=collinear_samples)
+    A_baba, A_abab = a
+    B_baab, B_abba = b
+    n_occ_a, n_virt_b = A_abab.shape[0], A_abab.shape[1]
+    n_occ_b, n_virt_a = B_abba.shape[2], B_abba.shape[3]
+    A_abab_2d = A_abab.reshape((n_occ_a*n_virt_b, n_occ_a*n_virt_b), order='C')
+    B_abba_2d = B_abba.reshape((n_occ_a*n_virt_b, n_occ_b*n_virt_a), order='C')
+    B_baab_2d = B_baab.reshape((n_occ_b*n_virt_a, n_occ_a*n_virt_b), order='C')
+    A_baba_2d = A_baba.reshape((n_occ_b*n_virt_a, n_occ_b*n_virt_a), order='C')
+    Casida_matrix = np.block([[ A_abab_2d, B_abba_2d],
+                              [-B_baab_2d, -A_baba_2d]])
+    eigenvals, eigenvecs = np.linalg.eig(Casida_matrix)
+    idx = eigenvals.real.argsort()
+    eigenvals = eigenvals[idx]
+    eigenvecs = eigenvecs[:, idx]
+    norms = np.linalg.norm(eigenvecs[:n_occ_a*n_virt_b], axis=0)**2
+    norms -= np.linalg.norm(eigenvecs[n_occ_a*n_virt_b:], axis=0)**2
+    if extype == 1:
+        mask = norms > 1e-3
+        valid_e = eigenvals[mask].real
+    else:
+        mask = norms < -1e-3
+        valid_e = eigenvals[mask].real
+        valid_e = -valid_e
+    lowest_e = np.sort(valid_e)[:nstates]
+    return lowest_e
+
+class KnownValues(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        mol = gto.Mole()
+        mol.verbose = 0
+        mol.output = '/dev/null'
+        mol.atom = '''
+        O     0.   0.       0.
+        H     0.   -0.757   0.587
+        H     0.   0.757    0.587'''
+        mol.spin = 2
+        mol.basis = '631g'
+        cls.mol = mol.build()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mol.stdout.close()
+
+    def test_hf_tddft(self):
+        mf = self.mol.UKS(xc='HF').run()
+        ref = np.array([0.4562711038, 0.5371281911])
+        td = mf.TDDFT_SF().set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2170068763,  0.0000000730])
+        td = mf.TDDFT_SF().set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_mcol_lda_tddft(self):
+        mf = self.mol.UKS(xc='SVWN').run()
+        ref = np.array([0.4496080754, 0.5767662743])
+        td = mf.TDDFT_SF().set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.3265808777, -0.0000058921])
+        td = mf.TDDFT_SF().set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_mcol_b3lyp_tddft(self):
+        mf = self.mol.UKS(xc='B3LYP').run()
+        ref = np.array([0.4575220751, 0.5729490946])
+        td = mf.TDDFT_SF().set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2966235764, -0.0000019816])
+        td = mf.TDDFT_SF().set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_col_b3lyp_tddft(self):
+        mf = self.mol.UKS(xc='B3LYP').run()
+        ref = np.array([0.4733607067, 0.6059909951])
+        td = mf.TDDFT_SF().set(extype=0, collinear="col", collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=0, collinear="col", collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2852484489,  0.0427271935])
+        td = mf.TDDFT_SF().set(extype=1, collinear="col", collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=1, collinear="col", collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_mcol_tpss_tddft(self):
+        mf = self.mol.UKS(xc='TPSS').run()
+        ref = np.array([0.4478240804, 0.5654751068])
+        td = mf.TDDFT_SF().set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2873951146,  0.0000023945])
+        td = mf.TDDFT_SF().set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_mcol_cam_tddft(self):
+        mf = self.mol.UKS(xc='CAM-B3LYP').run()
+        ref = np.array([0.4595200285, 0.5715324610])
+        td = mf.TDDFT_SF().set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2979398223, -0.0000007521])
+        td = mf.TDDFT_SF().set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_col_cam_tddft(self):
+        mf = self.mol.UKS(xc='CAM-B3LYP').run()
+        ref = np.array([0.4749112597, 0.6040293216])
+        td = mf.TDDFT_SF().set(extype=0, collinear="col", collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=0, collinear="col", collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2874776809,  0.0300218092])
+        td = mf.TDDFT_SF().set(extype=1, collinear="col", collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=1, collinear="col", collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+if __name__ == "__main__":
+    print("Full Tests for spin-flip-TDDFT with multicollinear functionals and collinear functionals")
+    unittest.main()

--- a/src/nest/sftda/tests/test_sftddft_roks.py
+++ b/src/nest/sftda/tests/test_sftddft_roks.py
@@ -1,0 +1,181 @@
+# Copyright 2021-2024 The PySCF Developers. All Rights Reserved.
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from pyscf import gto
+from nest import sftda
+
+def diagonalize_tddft(mf, extype=1, collinear="mcol", collinear_samples=50, nstates=5):
+    a, b = sftda.uhf_sf.get_ab_sf(mf, collinear=collinear, collinear_samples=collinear_samples)
+    A_baba, A_abab = a
+    B_baab, B_abba = b
+    n_occ_a, n_virt_b = A_abab.shape[0], A_abab.shape[1]
+    n_occ_b, n_virt_a = B_abba.shape[2], B_abba.shape[3]
+    A_abab_2d = A_abab.reshape((n_occ_a*n_virt_b, n_occ_a*n_virt_b), order='C')
+    B_abba_2d = B_abba.reshape((n_occ_a*n_virt_b, n_occ_b*n_virt_a), order='C')
+    B_baab_2d = B_baab.reshape((n_occ_b*n_virt_a, n_occ_a*n_virt_b), order='C')
+    A_baba_2d = A_baba.reshape((n_occ_b*n_virt_a, n_occ_b*n_virt_a), order='C')
+    Casida_matrix = np.block([[ A_abab_2d, B_abba_2d],
+                              [-B_baab_2d, -A_baba_2d]])
+    eigenvals, eigenvecs = np.linalg.eig(Casida_matrix)
+    idx = eigenvals.real.argsort()
+    eigenvals = eigenvals[idx]
+    eigenvecs = eigenvecs[:, idx]
+    norms = np.linalg.norm(eigenvecs[:n_occ_a*n_virt_b], axis=0)**2
+    norms -= np.linalg.norm(eigenvecs[n_occ_a*n_virt_b:], axis=0)**2
+    if extype == 1:
+        mask = norms > 1e-3
+        valid_e = eigenvals[mask].real
+    else:
+        mask = norms < -1e-3
+        valid_e = eigenvals[mask].real
+        valid_e = -valid_e
+    lowest_e = np.sort(valid_e)[:nstates]
+    return lowest_e
+
+class KnownValues(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        mol = gto.Mole()
+        mol.verbose = 0
+        mol.output = '/dev/null'
+        mol.atom = '''
+        O     0.   0.       0.
+        H     0.   -0.757   0.587
+        H     0.   0.757    0.587'''
+        mol.spin = 2
+        mol.basis = '631g'
+        cls.mol = mol.build()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mol.stdout.close()
+
+    def test_hf_tddft(self):
+        mf = self.mol.ROKS(xc='HF').run()
+        ref = np.array([0.4629615319, 0.5364066061])
+        td = sftda.TDDFT_SF(mf).set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2217270249, -0.005551913 ])
+        td = sftda.TDDFT_SF(mf).set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_mcol_lda_tddft(self):
+        mf = self.mol.ROKS(xc='SVWN').run()
+        ref = np.array([0.4502145189, 0.5768298978])
+        td = sftda.TDDFT_SF(mf).set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.3273393356, -0.0007545328])
+        td = sftda.TDDFT_SF(mf).set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_mcol_b3lyp_tddft(self):
+        mf = self.mol.ROKS(xc='B3LYP').run()
+        ref = np.array([0.4587747607, 0.5730181452])
+        td = sftda.TDDFT_SF(mf).set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2979532666, -0.0013290418])
+        td = sftda.TDDFT_SF(mf).set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_col_b3lyp_tddft(self):
+        mf = self.mol.ROKS(xc='B3LYP').run()
+        ref = np.array([0.4745987469, 0.6060827854])
+        td = sftda.TDDFT_SF(mf).set(extype=0, collinear="col", collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=0, collinear="col", collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2865625142,  0.041539444 ])
+        td = sftda.TDDFT_SF(mf).set(extype=1, collinear="col", collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=1, collinear="col", collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_mcol_tpss_tddft(self):
+        mf = self.mol.ROKS(xc='TPSS').run()
+        ref = np.array([0.4486464854, 0.5651121494])
+        td = sftda.TDDFT_SF(mf).set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2887465343, -0.0012673515])
+        td = sftda.TDDFT_SF(mf).set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_mcol_cam_tddft(self):
+        mf = self.mol.ROKS(xc='CAM-B3LYP').run()
+        ref = np.array([0.4609174566, 0.5715410876])
+        td = sftda.TDDFT_SF(mf).set(extype=0, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=0, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.2992951841, -0.001365193 ])
+        td = sftda.TDDFT_SF(mf).set(extype=1, collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=1, collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+    def test_col_cam_tddft(self):
+        mf = self.mol.ROKS(xc='CAM-B3LYP').run()
+        ref = np.array([0.4762639961, 0.6039715045])
+        td = sftda.TDDFT_SF(mf).set(extype=0, collinear="col", collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=0, collinear="col", collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+        ref = np.array([-0.288822456 ,  0.0288018552])
+        td = sftda.TDDFT_SF(mf).set(extype=1, collinear="col", collinear_samples=50, nstates=2).run()
+        self.assertTrue(np.all(td.converged))
+        self.assertAlmostEqual(abs(td.e - ref).max(), 0, 4)
+        e = diagonalize_tddft(mf, extype=1, collinear="col", collinear_samples=50, nstates=2)
+        self.assertAlmostEqual(abs(e - td.e).max(), 0, 4)
+
+if __name__ == "__main__":
+    print("Full Tests for spin-flip-TDDFT based on ROKS reference")
+    unittest.main()

--- a/src/nest/sftda/uhf_sf.py
+++ b/src/nest/sftda/uhf_sf.py
@@ -1,0 +1,950 @@
+#!/usr/bin/env python
+# Copyright 2014-2024 The PySCF Developers. All Rights Reserved.
+# Copyright 2026 The NEST Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import numpy as np
+from pyscf import lib
+from pyscf import scf, dft
+from pyscf import ao2mo
+from pyscf.lib import logger
+from pyscf.tdscf import rhf
+from pyscf import __config__
+from pyscf import symm
+from pyscf.data import nist
+
+from nest.sftda.scf_genrep_sftd import gen_uhf_response_sf
+from nest.sftda.numint2c_sftd import cache_xc_kernel_sf
+from nest.sftda._lr_eig import eigh, davidson_nosym1
+
+# import class
+from pyscf.tdscf.uhf import TDBase
+from pyscf.scf import uhf_symm
+
+MO_BASE = getattr(__config__, 'MO_BASE', 1)
+
+def oscillator_strength(tdobj, ref=1, state=None):
+    r'''
+    Oscillator strengths between excited states for spin-flip TDDFT/TDA.
+    Only applicable to length gauge.
+
+    Args:
+            tdobj : an instance of TDA_SF/TDDFT_SF
+            ref : int
+                Index of the reference excited state (1-based). Default is 1.
+            state : int, list, or ndarray, optional
+                Index/indices of the target excited state(s) (1-based).
+                If None, all excited states except the 'ref' state are calculated.
+
+        Returns:
+            float or ndarray
+            Oscillator strength(s) between the reference and target state(s).
+    '''
+    if state is None:
+        states = np.arange(tdobj.nstates) + 1
+    else:
+        states = np.atleast_1d(state)
+    states = states[states != ref]
+
+    trans_dip = transition_dipole(tdobj, ref, states)
+
+    ref -= 1
+    states -= 1
+    es = tdobj.e[states] - tdobj.e[ref]
+    f = (2./3.) * lib.einsum('n,nx,nx->n', es, trans_dip.conj(), trans_dip).real
+    if isinstance(state, int):
+        return f[0]
+    else:
+        return f
+
+def transition_dipole(tdobj, ref=1, state=None):
+    '''
+    Transition dipole moments between excited states for Spin-flip TDDFT/TDA.
+    Only applicable to length gauge.
+    '''
+    if state is None:
+        states = np.arange(tdobj.nstates) + 1
+    else:
+        states = np.atleast_1d(state)
+    states = states[states != ref]
+    ref -= 1
+    states -= 1
+
+    mf = tdobj._scf
+    mo_coeff = mf.mo_coeff
+    mo_occ = mf.mo_occ
+    occidxa = mo_occ[0] > 0
+    occidxb = mo_occ[1] > 0
+    viridxa = mo_occ[0] == 0
+    viridxb = mo_occ[1] == 0
+    orboa = mo_coeff[0][:, occidxa]
+    orbob = mo_coeff[1][:, occidxb]
+    orbva = mo_coeff[0][:, viridxa]
+    orbvb = mo_coeff[1][:, viridxb]
+
+    mx = tdobj.xy[ref][0]
+    nxs = np.array([tdobj.xy[i][0] for i in states])
+    if isinstance(tdobj.xy[0][1], np.ndarray):
+        my = tdobj.xy[ref][1]
+        nys = np.array([tdobj.xy[i][1] for i in states])
+    else:
+        nys = None
+        my = None
+    if tdobj.extype==0:
+        gamma_oo_bb = - lib.einsum('ia,nja->nij', mx.conj(), nxs)
+        gamma_bb = lib.einsum('uj,vi,nij->nvu', orbob.conj(), orbob, gamma_oo_bb)
+        gamma_vv_aa = lib.einsum('ib,nia->nab', mx.conj(), nxs)
+        gamma_aa = lib.einsum('ub,va,nab->nvu', orbva.conj(), orbva, gamma_vv_aa)
+        if my is not None:
+            gamma_oo_aa = - lib.einsum('ja,nia->nij', my.conj(), nys)
+            gamma_aa += lib.einsum('uj,vi,nij->nvu', orboa.conj(), orboa, gamma_oo_aa)
+            gamma_vv_bb = lib.einsum('ia,nib->nab', my.conj(), nys)
+            gamma_bb += lib.einsum('ub,va,nab->nvu', orbvb.conj(), orbvb, gamma_vv_bb)
+    elif tdobj.extype==1:
+        gamma_oo_aa = - lib.einsum('ia,nja->nij', mx.conj(), nxs)
+        gamma_aa = lib.einsum('uj,vi,nij->nvu', orboa.conj(), orboa, gamma_oo_aa)
+        gamma_vv_bb = lib.einsum('ib,nia->nab', mx.conj(), nxs)
+        gamma_bb = lib.einsum('ub,va,nab->nvu', orbvb.conj(), orbvb, gamma_vv_bb)
+        if my is not None:
+            gamma_oo_bb = - lib.einsum('ja,nia->nij', my.conj(), nys)
+            gamma_bb += lib.einsum('uj,vi,nij->nvu', orbob.conj(), orbob, gamma_oo_bb)
+            gamma_vv_aa = lib.einsum('ia,nib->nab', my.conj(), nys)
+            gamma_aa += lib.einsum('ub,va,nab->nvu', orbva.conj(), orbva, gamma_vv_aa)
+
+    gamma = gamma_aa + gamma_bb
+    dip_int = mf.mol.intor_symmetric('int1e_r', comp=3)
+    pol = lib.einsum('nvu,xuv->nx', gamma, dip_int)
+    return pol.real
+
+def spin_square(tdobj, state=None):
+    r'''
+    <S^2> of excited states for Spin-flip TDDFT/TDA.
+    Ref: J. Chem. Phys. 2011, 134, 134101.
+
+    Args:
+            tdobj : an instance of TDA_SF/TDDFT_SF
+            state : int, list, or ndarray, optional
+                Index/indices of the target excited state(s) (1-based).
+                If None, all excited states are calculated.
+
+    Returns:
+            float or ndarray
+            <S^2> of the target excited state(s).
+    '''
+    mf = tdobj._scf
+    s20, _ = mf.spin_square()
+    sz = mf.mol.spin / 2.0
+
+    mo_coeff = mf.mo_coeff
+    mo_occ = mf.mo_occ
+    occidxa = mo_occ[0] > 0
+    occidxb = mo_occ[1] > 0
+    viridxa = mo_occ[0] == 0
+    viridxb = mo_occ[1] == 0
+    orboa = mo_coeff[0][:, occidxa]
+    orbob = mo_coeff[1][:, occidxb]
+    orbva = mo_coeff[0][:, viridxa]
+    orbvb = mo_coeff[1][:, viridxb]
+
+    ovlp = mf.get_ovlp()
+    sab_oo = orboa.conj().T @ ovlp @ orbob
+    sba_oo = sab_oo.conj().T
+    sab_vo = orbva.conj().T @ ovlp @ orbob
+    sba_ov = sab_vo.conj().T
+    sba_vo = orbvb.conj().T @ ovlp @ orboa
+    sab_ov = sba_vo.conj().T
+
+    if state is None:
+        states = np.arange(tdobj.nstates)
+    else:
+        states = np.atleast_1d(state) - 1
+    xs = np.array([tdobj.xy[i][0].T for i in states])
+    if isinstance(tdobj.xy[0][1], np.ndarray):
+        ys = np.array([tdobj.xy[i][1].T for i in states])
+    else:
+        ys = None
+
+    if tdobj.extype==0:
+        assert xs[0].shape==sab_vo.shape
+        P_ab = lib.einsum('nai,naj,jk,ki->n', xs.conj(), xs, sba_oo, sab_oo) \
+               - lib.einsum('nai,nbi,kb,ak->n', xs.conj(), xs, sba_ov, sab_vo) \
+               + lib.einsum('nai,nbj,jb,ai->n', xs.conj(), xs, sba_ov, sab_vo)
+        if ys is not None:
+            assert ys[0].shape==sba_vo.shape
+            P_ab += lib.einsum('nai,naj,ik,kj->n', ys.conj(), ys, sab_oo, sba_oo) \
+                    - lib.einsum('nai,nbi,ka,bk->n', ys.conj(), ys, sab_ov, sba_vo) \
+                    + lib.einsum('nai,nbj,ia,bj->n', ys.conj(), ys, sab_ov, sba_vo) \
+                    - 2 * lib.einsum('nai,nbj,ai,bj->n', xs.conj(), ys, sab_vo, sba_vo).real
+        ds2 = P_ab + 2 * sz + 1
+    elif tdobj.extype==1:
+        assert xs[0].shape==sba_vo.shape
+        P_ab = lib.einsum('nai,naj,jk,ki->n', xs.conj(), xs, sab_oo, sba_oo) \
+               - lib.einsum('nai,nbi,kb,ak->n', xs.conj(), xs, sab_ov, sba_vo) \
+               + lib.einsum('nai,nbj,jb,ai->n', xs.conj(), xs, sab_ov, sba_vo)
+        if ys is not None:
+            assert ys[0].shape==sab_vo.shape
+            P_ab += lib.einsum('nai,naj,ik,kj->n', ys.conj(), ys, sba_oo, sab_oo) \
+                    - lib.einsum('nai,nbi,ka,bk->n', ys.conj(), ys, sba_ov, sab_vo) \
+                    + lib.einsum('nai,nbj,ia,bj->n', ys.conj(), ys, sba_ov, sab_vo) \
+                    - 2 * lib.einsum('nai,nbj,ai,bj->n', xs.conj(), ys, sba_vo, sab_vo).real
+        ds2 = P_ab - 2 * sz + 1
+
+    s2s = s20 + ds2.real
+    if isinstance(state, int):
+        return s2s[0]
+    else:
+        return s2s
+
+def _analyze_wfnsym(tdobj, x_sym, x):
+    '''
+    Guess the excitation symmetry of TDDFT X amplitude.
+    Return a label.
+    x_sym and x are of the same shape.'''
+    possible_sym = x_sym[(x > 0.1) | (x < -0.1)]
+    wfnsym = symm.MULTI_IRREPS
+    ids = possible_sym[possible_sym != symm.MULTI_IRREPS]
+    if len(ids) > 0 and all(ids == ids[0]):
+        wfnsym = ids[0]
+    if wfnsym == symm.MULTI_IRREPS:
+        wfnsym_label = '???'
+    else:
+        wfnsym_label = symm.irrep_id2name(tdobj.mol.groupname, wfnsym)
+    return wfnsym, wfnsym_label
+
+def analyze(tdobj, verbose=None):
+    log = logger.new_logger(tdobj, verbose)
+    mol = tdobj.mol
+    maska, maskb = tdobj.get_frozen_mask()
+    mo_coeff = (tdobj._scf.mo_coeff[0][:, maska], tdobj._scf.mo_coeff[1][:, maskb])
+    mo_occ = (tdobj._scf.mo_occ[0][maska], tdobj._scf.mo_occ[1][maskb])
+    nocc_a = np.count_nonzero(mo_occ[0] == 1)
+    nocc_b = np.count_nonzero(mo_occ[1] == 1)
+
+    if mol.symmetry and mol.groupname!='C1':
+        orbsyma, orbsymb = uhf_symm.get_orbsym(mol, mo_coeff)
+        x_symab = symm.direct_prod(orbsyma[mo_occ[0]==1], orbsymb[mo_occ[1]==0], mol.groupname)
+        x_symba = symm.direct_prod(orbsymb[mo_occ[1]==1], orbsyma[mo_occ[0]==0], mol.groupname)
+    else:
+        x_symab = x_symba = None
+    S2s = spin_square(tdobj)
+    for i in range(tdobj.nstates):
+        x, y = tdobj.xy[i]
+        if tdobj.extype==0:
+            x_sym = x_symba
+        elif tdobj.extype==1:
+            x_sym = x_symab
+        S2 = S2s[i]
+        e_ev = np.asarray(tdobj.e[i]) * nist.HARTREE2EV
+        if x_symab is None:
+            log.note('Excited State %3d: %12.5f eV   <S^2>: %6.4f', i+1, e_ev, S2)
+        else:
+            wfnsymid, wfnsymlabel = _analyze_wfnsym(tdobj, x_sym, x)
+            refsym = tdobj._scf.get_wfnsym()
+            statesymid = wfnsymid ^ refsym
+            if refsym == symm.MULTI_IRREPS or wfnsymid == symm.MULTI_IRREPS:
+                statesymlabel = '???'
+            else:
+                statesymlabel = symm.irrep_id2name(mol.groupname, statesymid)
+            log.note('Excited State %3d: %4s (State: %4s) %12.5f eV   <S^2>: %6.4f',
+                     i+1, wfnsymlabel, statesymlabel, e_ev, S2)
+
+        if log.verbose >= logger.INFO:
+            if tdobj.extype==0:
+                for o, v in zip(* np.where(abs(x) > 0.1)):
+                    log.info('    %4db -> %4da %12.5f', o+MO_BASE, v+MO_BASE+nocc_a, x[o,v])
+            elif tdobj.extype==1:
+                for o, v in zip(* np.where(abs(x) > 0.1)):
+                    log.info('    %4da -> %4db %12.5f', o+MO_BASE, v+MO_BASE+nocc_b, x[o,v])
+
+def get_ab_sf(
+    mf,
+    mo_energy=None,
+    mo_coeff=None,
+    mo_occ=None,
+    collinear="mcol",
+    collinear_samples=20,
+):
+    r'''A and B matrices for TDDFT response function.
+
+    A[i,a,j,b] = \delta_{ab}\delta_{ij}(E_a - E_i) + (ia||bj)
+    B[i,a,j,b] = (ia||jb)
+
+    Spin symmetry is not considered in the returned A, B lists.
+    List A has two items: (A_baba, A_abab).
+    List B has two items: (B_baab, B_abba).
+    '''
+    if isinstance(mf, scf.rohf.ROHF) or isinstance(mf, scf.hf_symm.SymAdaptedROHF):
+        if isinstance(mf, dft.roks.ROKS) or isinstance(mf, dft.rks_symm.SymAdaptedROKS):
+            mf = mf.to_uks()
+        else:
+            mf = mf.to_uhf()
+    if mo_energy is None:
+        mo_energy = mf.mo_energy
+    if mo_coeff is None:
+        mo_coeff = mf.mo_coeff
+    if mo_occ is None:
+        mo_occ = mf.mo_occ
+
+    mol = mf.mol
+    nao = mol.nao_nr()
+    occidx_a = np.where(mo_occ[0]==1)[0]
+    viridx_a = np.where(mo_occ[0]==0)[0]
+    occidx_b = np.where(mo_occ[1]==1)[0]
+    viridx_b = np.where(mo_occ[1]==0)[0]
+    orbo_a = mo_coeff[0][:,occidx_a]
+    orbv_a = mo_coeff[0][:,viridx_a]
+    orbo_b = mo_coeff[1][:,occidx_b]
+    orbv_b = mo_coeff[1][:,viridx_b]
+    nocc_a = orbo_a.shape[1]
+    nvir_a = orbv_a.shape[1]
+    nocc_b = orbo_b.shape[1]
+    nvir_b = orbv_b.shape[1]
+
+    if np.allclose(mf.mo_coeff[0], mf.mo_coeff[1]):
+        logger.info(mf, 'Restricted open-shell detected.')
+        fock_ao_a, fock_ao_b = mf.get_fock()
+        fock_oo_a = orbo_a.T @ fock_ao_a @ orbo_a
+        fock_vv_a = orbv_a.T @ fock_ao_a @ orbv_a
+        fock_oo_b = orbo_b.T @ fock_ao_b @ orbo_b
+        fock_vv_b = orbv_b.T @ fock_ao_b @ orbv_b
+
+        a_b2a = np.zeros((nocc_b,nvir_a,nocc_b,nvir_a))
+        a_a2b = np.zeros((nocc_a,nvir_b,nocc_a,nvir_b))
+        a_b2a += lib.einsum('ik,ab->iakb', np.eye(nocc_b), fock_vv_a)
+        a_b2a -= lib.einsum('ac,ik->iakc', np.eye(nvir_a), fock_oo_b.T)
+        a_a2b += lib.einsum('ik,ab->iakb', np.eye(nocc_a), fock_vv_b)
+        a_a2b -= lib.einsum('ac,ik->iakc', np.eye(nvir_b), fock_oo_a.T)
+
+    else:
+        e_ia_b2a = (mo_energy[0][viridx_a,None] - mo_energy[1][occidx_b]).T
+        e_ia_a2b = (mo_energy[1][viridx_b,None] - mo_energy[0][occidx_a]).T
+
+        a_b2a = np.diag(e_ia_b2a.ravel()).reshape(nocc_b,nvir_a,nocc_b,nvir_a)
+        a_a2b = np.diag(e_ia_a2b.ravel()).reshape(nocc_a,nvir_b,nocc_a,nvir_b)
+    b_b2a = np.zeros((nocc_b,nvir_a,nocc_a,nvir_b))
+    b_a2b = np.zeros((nocc_a,nvir_b,nocc_b,nvir_a))
+    a = (a_b2a, a_a2b)
+    b = (b_b2a, b_a2b)
+
+    def add_hf_(a, b, hyb=1):
+        # In spin flip TDA/ TDDFT, hartree potential is zero.
+        # A : iabj ---> ijba; B : iajb ---> ibja
+        eri_a_b2a = ao2mo.general(mol, [orbo_b,orbo_b,orbv_a,orbv_a], compact=False)
+        eri_a_a2b = ao2mo.general(mol, [orbo_a,orbo_a,orbv_b,orbv_b], compact=False)
+        eri_b_b2a = ao2mo.general(mol, [orbo_b,orbv_b,orbo_a,orbv_a], compact=False)
+        eri_b_a2b = ao2mo.general(mol, [orbo_a,orbv_a,orbo_b,orbv_b], compact=False)
+
+        eri_a_b2a = eri_a_b2a.reshape(nocc_b,nocc_b,nvir_a,nvir_a)
+        eri_a_a2b = eri_a_a2b.reshape(nocc_a,nocc_a,nvir_b,nvir_b)
+        eri_b_b2a = eri_b_b2a.reshape(nocc_b,nvir_b,nocc_a,nvir_a)
+        eri_b_a2b = eri_b_a2b.reshape(nocc_a,nvir_a,nocc_b,nvir_b)
+
+        a_b2a, a_a2b = a
+        b_b2a, b_a2b = b
+
+        a_b2a-= lib.einsum('ijba->iajb', eri_a_b2a) * hyb
+        a_a2b-= lib.einsum('ijba->iajb', eri_a_a2b) * hyb
+        b_b2a-= lib.einsum('ibja->iajb', eri_b_b2a) * hyb
+        b_a2b-= lib.einsum('ibja->iajb', eri_b_a2b) * hyb
+
+    if isinstance(mf, dft.KohnShamDFT):
+        if collinear not in ("col", "mcol"):
+            raise ValueError("collinear must be 'col' or 'mcol'")
+
+        from pyscf.dft import numint2c
+        ni0 = mf._numint
+        ni = numint2c.NumInt2C()
+        ni.collinear = collinear
+        ni.collinear_samples = collinear_samples
+        ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
+        if mf.nlc or ni.libxc.is_nlc(mf.xc):
+            logger.warn(mf, 'NLC functional found in DFT object.  Its second '
+                        'deriviative is not available. Its contribution is '
+                        'not included in the response function.')
+        omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
+
+        add_hf_(a, b, hyb)
+
+        if omega != 0:
+            with mol.with_range_coulomb(omega):
+                eri_a_b2a = ao2mo.general(mol, [orbo_b,orbo_b,orbv_a,orbv_a], compact=False)
+                eri_a_a2b = ao2mo.general(mol, [orbo_a,orbo_a,orbv_b,orbv_b], compact=False)
+                eri_b_b2a = ao2mo.general(mol, [orbo_b,orbv_b,orbo_a,orbv_a], compact=False)
+                eri_b_a2b = ao2mo.general(mol, [orbo_a,orbv_a,orbo_b,orbv_b], compact=False)
+
+                eri_a_b2a = eri_a_b2a.reshape(nocc_b,nocc_b,nvir_a,nvir_a)
+                eri_a_a2b = eri_a_a2b.reshape(nocc_a,nocc_a,nvir_b,nvir_b)
+                eri_b_b2a = eri_b_b2a.reshape(nocc_b,nvir_b,nocc_a,nvir_a)
+                eri_b_a2b = eri_b_a2b.reshape(nocc_a,nvir_a,nocc_b,nvir_b)
+
+                k_fac = alpha - hyb
+                a_b2a, a_a2b = a
+                b_b2a, b_a2b = b
+                a_b2a -= lib.einsum('ijba->iajb', eri_a_b2a) * k_fac
+                a_a2b -= lib.einsum('ijba->iajb', eri_a_a2b) * k_fac
+                b_b2a -= lib.einsum('ibja->iajb', eri_b_b2a) * k_fac
+                b_a2b -= lib.einsum('ibja->iajb', eri_b_a2b) * k_fac
+
+        if collinear == "col":
+            return a, b
+
+        xctype = ni._xc_type(mf.xc)
+        mem_now = lib.current_memory()[0]
+        max_memory = max(2000, mf.max_memory*.8-mem_now)
+
+        # it should be optimized, which is the disadvantage of mc approach.
+        fxc = cache_xc_kernel_sf(ni, mol, mf.grids, mf.xc, mo_coeff, mo_occ,deriv=2,spin=1)[2]
+        p0,p1=0,0 # the two parameters are used for counts the batch of grids.
+
+        if xctype == 'LDA':
+            ao_deriv = 0
+            for ao, mask, weight, coords \
+                    in ni0.block_loop(mol, mf.grids, nao, ao_deriv, max_memory):
+                p0 = p1
+                p1+= weight.shape[0]
+                wfxc= fxc[0,0][...,p0:p1] * weight
+
+                rho_o_a = lib.einsum('rp,pi->ri', ao, orbo_a)
+                rho_v_a = lib.einsum('rp,pi->ri', ao, orbv_a)
+                rho_o_b = lib.einsum('rp,pi->ri', ao, orbo_b)
+                rho_v_b = lib.einsum('rp,pi->ri', ao, orbv_b)
+                rho_ov_b2a = lib.einsum('ri,ra->ria', rho_o_b, rho_v_a)
+                rho_ov_a2b = lib.einsum('ri,ra->ria', rho_o_a, rho_v_b)
+
+                w_ov = lib.einsum('ria,r->ria', rho_ov_b2a, wfxc*2.0)
+                iajb = lib.einsum('ria,rjb->iajb', rho_ov_b2a, w_ov)
+                a_b2a += iajb
+                iajb = lib.einsum('ria,rjb->iajb', rho_ov_a2b, w_ov)
+                b_a2b += iajb
+
+                w_ov = lib.einsum('ria,r->ria', rho_ov_a2b, wfxc*2.0)
+                iajb = lib.einsum('ria,rjb->iajb', rho_ov_a2b, w_ov)
+                a_a2b += iajb
+                iajb = lib.einsum('ria,rjb->iajb', rho_ov_b2a, w_ov)
+                b_b2a += iajb
+
+        elif xctype == 'GGA':
+            ao_deriv = 1
+            for ao, mask, weight, coords \
+                    in ni.block_loop(mol, mf.grids, nao, ao_deriv, max_memory):
+                p0 = p1
+                p1+= weight.shape[0]
+                wfxc= fxc[...,p0:p1] * weight
+
+                rho_o_a = lib.einsum('xrp,pi->xri', ao, orbo_a)
+                rho_v_a = lib.einsum('xrp,pi->xri', ao, orbv_a)
+                rho_o_b = lib.einsum('xrp,pi->xri', ao, orbo_b)
+                rho_v_b = lib.einsum('xrp,pi->xri', ao, orbv_b)
+                rho_ov_b2a = lib.einsum('xri,ra->xria', rho_o_b, rho_v_a[0])
+                rho_ov_a2b = lib.einsum('xri,ra->xria', rho_o_a, rho_v_b[0])
+                rho_ov_b2a[1:4] += lib.einsum('ri,xra->xria', rho_o_b[0], rho_v_a[1:4])
+                rho_ov_a2b[1:4] += lib.einsum('ri,xra->xria', rho_o_a[0], rho_v_b[1:4])
+
+                w_ov = lib.einsum('xyr,xria->yria', wfxc*2.0, rho_ov_b2a)
+                iajb = lib.einsum('xria,xrjb->iajb', w_ov, rho_ov_b2a)
+                a_b2a += iajb
+                iajb = lib.einsum('xria,xrjb->iajb', w_ov, rho_ov_a2b)
+                b_b2a += iajb
+
+                w_ov = lib.einsum('xyr,xria->yria', wfxc*2.0, rho_ov_a2b)
+                iajb = lib.einsum('xria,xrjb->iajb', w_ov, rho_ov_a2b)
+                a_a2b += iajb
+                iajb = lib.einsum('xria,xrjb->iajb', w_ov, rho_ov_b2a)
+                b_a2b += iajb
+
+        elif xctype == 'HF':
+            pass
+
+        elif xctype == 'NLC':
+            raise NotImplementedError('NLC')
+
+        elif xctype == 'MGGA':
+            ao_deriv = 1
+            for ao, mask, weight, coords \
+                    in ni.block_loop(mol, mf.grids, nao, ao_deriv, max_memory):
+                p0 = p1
+                p1+= weight.shape[0]
+                wfxc = fxc[...,p0:p1] * weight
+
+                rho_oa = lib.einsum('xrp,pi->xri', ao, orbo_a)
+                rho_ob = lib.einsum('xrp,pi->xri', ao, orbo_b)
+                rho_va = lib.einsum('xrp,pi->xri', ao, orbv_a)
+                rho_vb = lib.einsum('xrp,pi->xri', ao, orbv_b)
+                rho_ov_b2a = lib.einsum('xri,ra->xria', rho_ob, rho_va[0])
+                rho_ov_a2b = lib.einsum('xri,ra->xria', rho_oa, rho_vb[0])
+                rho_ov_b2a[1:4] += lib.einsum('ri,xra->xria', rho_ob[0], rho_va[1:4])
+                rho_ov_a2b[1:4] += lib.einsum('ri,xra->xria', rho_oa[0], rho_vb[1:4])
+                tau_ov_b2a = lib.einsum('xri,xra->ria', rho_ob[1:4], rho_va[1:4]) * .5
+                tau_ov_a2b = lib.einsum('xri,xra->ria', rho_oa[1:4], rho_vb[1:4]) * .5
+                rho_ov_b2a = np.vstack([rho_ov_b2a, tau_ov_b2a[np.newaxis]])
+                rho_ov_a2b = np.vstack([rho_ov_a2b, tau_ov_a2b[np.newaxis]])
+
+                w_ov = lib.einsum('xyr,xria->yria', wfxc*2.0, rho_ov_b2a)
+                iajb = lib.einsum('xria,xrjb->iajb', w_ov, rho_ov_b2a)
+                a_b2a += iajb
+                iajb = lib.einsum('xria,xrjb->iajb', w_ov, rho_ov_a2b)
+                b_b2a += iajb
+
+                w_ov = lib.einsum('xyr,xria->yria', wfxc*2.0, rho_ov_a2b)
+                iajb = lib.einsum('xria,xrjb->iajb', w_ov, rho_ov_a2b)
+                a_a2b += iajb
+                iajb = lib.einsum('xria,xrjb->iajb', w_ov, rho_ov_b2a)
+                b_a2b += iajb
+    else:
+        add_hf_(a, b)
+
+    return a, b
+
+@lib.with_doc(rhf.TDA.__doc__)
+class TDA_SF(TDBase):
+    extype = 1
+    collinear = 'mcol'
+    collinear_samples = 20
+
+    _keys = {'extype', 'collinear', 'collinear_samples'}
+
+    def __init__(self, mf, extype=1, collinear="mcol", collinear_samples=20):
+        TDBase.__init__(self,mf)
+        # extype is used to determine which spin flip excitation will be calculated.
+        # spin flip up: exytpe=0, spin flip down: exytpe=1.
+        self.extype = extype
+        self.collinear = collinear
+        # collinear_samples controls the 1d spin sample points in TDDFT/TDA.
+        self.collinear_samples = collinear_samples
+
+    def dump_flags(self, verbose=None):
+        TDBase.dump_flags(self, verbose)
+        log = logger.new_logger(self, verbose)
+        log.info("extype = %s", self.extype)
+        log.info("collinear = %s", self.collinear)
+        if self.collinear == "mcol":
+            log.info("collinear_samples = %s", self.collinear_samples)
+        return self
+
+    def check_sanity(self):
+        if self.extype not in (0, 1):
+            raise ValueError("extype must be 0 or 1")
+        if self.collinear not in ("col", "mcol"):
+            raise ValueError("collinear must be 'col' or 'mcol'")
+        if self.collinear=='mcol' and self.collinear_samples <= 0:
+            raise ValueError("collinear_samples must be positive")
+        TDBase.check_sanity(self)
+        return self
+
+    def gen_vind(self):
+        '''
+        Generate function to compute A*x for spin-flip TDDFT case.
+        '''
+        mf = self._scf
+        mo_energy = mf.mo_energy
+        mo_coeff = mf.mo_coeff
+        assert (mo_coeff[0].dtype == np.double)
+        mo_occ = mf.mo_occ
+
+        extype = self.extype
+        if extype==0:
+            occidxb = mo_occ[1] > 0
+            viridxa = mo_occ[0] == 0
+            orbo = mo_coeff[1][:, occidxb]
+            orbv = mo_coeff[0][:, viridxa]
+            ndim = (int(occidxb.sum()), int(viridxa.sum()))
+            if np.allclose(mo_coeff[0], mo_coeff[1]):
+                fock_a, fock_b = mf.get_fock()
+                focko = orbo.conj().T @ fock_b @ orbo
+                fockv = orbv.conj().T @ fock_a @ orbv
+                hdiag = (fockv.diagonal()[None, :] - focko.diagonal()[:, None]).ravel()
+            else:
+                e_ia = (mo_energy[0][None, viridxa] - mo_energy[1][occidxb, None])
+                hdiag = e_ia.ravel()
+        elif extype==1:
+            occidxa = mo_occ[0] > 0
+            viridxb = mo_occ[1] == 0
+            orbo = mo_coeff[0][:, occidxa]
+            orbv = mo_coeff[1][:, viridxb]
+            ndim = (int(occidxa.sum()), int(viridxb.sum()))
+            if np.allclose(mo_coeff[0], mo_coeff[1]):
+                fock_a, fock_b = mf.get_fock()
+                focko = orbo.conj().T @ fock_a @ orbo
+                fockv = orbv.conj().T @ fock_b @ orbv
+                hdiag = (fockv.diagonal()[None, :] - focko.diagonal()[:, None]).ravel()
+            else:
+                e_ia = (mo_energy[1][None, viridxb] - mo_energy[0][occidxa, None])
+                hdiag = e_ia.ravel()
+
+        # TODO: change the response function
+        vresp = gen_uhf_response_sf(
+            mf,
+            hermi=0,
+            collinear=self.collinear,
+            collinear_samples=self.collinear_samples,
+        )
+
+        def vind(zs):
+            zs = np.asarray(zs).reshape(-1, *ndim)
+            dms = lib.einsum('xov,pv,qo->xpq', zs, orbv, orbo.conj())
+            v1ao = vresp(dms)
+            v1mo = lib.einsum('xpq,qo,pv->xov', v1ao, orbo, orbv.conj())
+            if np.allclose(mo_coeff[0], mo_coeff[1]):
+                v1mo += lib.einsum('ab,xib->xia', fockv, zs)
+                v1mo -= lib.einsum('ji,xja->xia', focko, zs)
+            else:
+                v1mo += zs * e_ia
+            return v1mo.reshape(len(v1mo), -1)
+
+        return vind, hdiag
+
+    def _init_guess(self, mf, nstates):
+        mo_energy = mf.mo_energy
+        mo_occ = mf.mo_occ
+
+        if self.extype==0:
+            occidxb = mo_occ[1] > 0
+            viridxa = mo_occ[0] == 0
+            e_ia = mo_energy[0][None, viridxa] - mo_energy[1][occidxb, None]
+        elif self.extype==1:
+            occidxa = mo_occ[0] > 0
+            viridxb = mo_occ[1] == 0
+            e_ia = mo_energy[1][None, viridxb] - mo_energy[0][occidxa, None]
+
+        e_ia = e_ia.ravel()
+        nov = e_ia.size
+        nstates = min(nstates, nov)
+        e_threshold = np.partition(e_ia, nstates-1)[nstates-1]
+        e_threshold += self.deg_eia_thresh
+        idx = np.where(e_ia <= e_threshold)[0]
+        nstates = idx.size
+        idx = idx[np.argsort(e_ia[idx])]
+        x0 = np.zeros((nstates, nov))
+        for i, j in enumerate(idx):
+            x0[i, j] = 1   # Koopmans' excitations
+        return x0
+
+    def init_guess(self, mf=None, nstates=None, wfnsym=None):
+        if mf is None:
+            mf = self._scf
+        if nstates is None:
+            nstates = self.nstates
+        nstates += 3
+        x0 = self._init_guess(mf, nstates)
+        return x0
+
+    def kernel(self, x0=None, nstates=None, extype=None):
+        '''
+        Spin-Flip TDA diagonalization solver
+        '''
+        cpu0 = (logger.process_clock(), logger.perf_counter())
+
+        self.check_sanity()
+        self.dump_flags()
+
+        if extype is None:
+            extype = self.extype
+        else:
+            self.extype = extype
+
+        if nstates is None:
+            nstates = self.nstates
+        else:
+            self.nstates = nstates
+
+        log = logger.Logger(self.stdout, self.verbose)
+
+        def all_eigs(w, v, nroots, envs):
+            return w, v, np.arange(w.size)
+
+        vind, hdiag = self.gen_vind()
+        precond = self.get_precond(hdiag)
+
+        x0sym = None
+        if x0 is None:
+            x0 = self.init_guess()
+
+        self.converged, self.e, x1 = eigh(
+            vind, x0, precond, tol_residual=self.conv_tol, lindep=self.lindep,
+            nroots=nstates, x0sym=x0sym, pick=all_eigs, max_cycle=self.max_cycle,
+            max_memory=self.max_memory, verbose=log)
+
+        nmo = self._scf.mo_occ[0].size
+        nocca, noccb = self._scf.nelec
+        nvira = nmo - nocca
+        nvirb = nmo - noccb
+
+        if self.extype==0:
+            self.xy = [(xi.reshape(noccb, nvira), 0) for xi in x1]
+        elif self.extype==1:
+            self.xy = [(xi.reshape(nocca, nvirb), 0) for xi in x1]
+
+        if self.chkfile:
+            lib.chkfile.save(self.chkfile, 'tddft/e', self.e)
+            lib.chkfile.save(self.chkfile, 'tddft/xy', self.xy)
+
+        log.timer('TDA_SF', *cpu0)
+        self._finalize()
+        return self.e, self.xy
+
+    def get_ab_sf(self, mf=None, collinear=None, collinear_samples=None):
+        if mf is None:
+            mf = self._scf
+        if collinear is None:
+            collinear = self.collinear
+        if collinear_samples is None:
+            collinear_samples = self.collinear_samples
+        return get_ab_sf(
+            mf,
+            collinear=collinear,
+            collinear_samples=collinear_samples,
+        )
+
+    def Gradients(self):
+        from nest.grad import tduks_sf
+        return tduks_sf.Gradients(self)
+
+    analyze = analyze
+    transition_dipole = transition_dipole
+    oscillator_strength = oscillator_strength
+    spin_square = spin_square
+
+
+class TDDFT_SF(TDA_SF):
+    '''Solve the Casida TDDFT formula
+       [ A  B][X]
+       [-B -A][Y]
+    '''
+
+    def gen_vind(self):
+        mf = self._scf
+        mo_energy = mf.mo_energy
+        mo_coeff = mf.mo_coeff
+        assert (mo_coeff[0].dtype == np.double)
+        mo_occ = mf.mo_occ
+
+        occidxa = mo_occ[0] > 0
+        occidxb = mo_occ[1] > 0
+        viridxa = mo_occ[0] == 0
+        viridxb = mo_occ[1] == 0
+        orboa = mo_coeff[0][:, occidxa]
+        orbob = mo_coeff[1][:, occidxb]
+        orbva = mo_coeff[0][:, viridxa]
+        orbvb = mo_coeff[1][:,viridxb]
+        nocca = int(occidxa.sum())
+        noccb = int(occidxb.sum())
+        nvira = int(viridxa.sum())
+        nvirb = int(viridxb.sum())
+
+        if np.allclose(mo_coeff[0], mo_coeff[1]):
+            fock_a, fock_b = mf.get_fock()
+            fockoa = orboa.conj().T @ fock_a @ orboa
+            fockva = orbva.conj().T @ fock_a @ orbva
+            fockob = orbob.conj().T @ fock_b @ orbob
+            fockvb = orbvb.conj().T @ fock_b @ orbvb
+            if self.extype==0:
+                hdiag1 = (fockva.diagonal()[None, :] - fockob.diagonal()[:, None]).ravel()
+                hdiag2 = - (fockvb.diagonal()[None, :] - fockoa.diagonal()[:, None]).ravel()
+                hdiag = np.hstack((hdiag1, hdiag2))
+            elif self.extype==1:
+                hdiag1 = (fockvb.diagonal()[None, :] - fockoa.diagonal()[:, None]).ravel()
+                hdiag2 = - (fockva.diagonal()[None, :] - fockob.diagonal()[:, None]).ravel()
+                hdiag = np.hstack((hdiag1, hdiag2))
+        else:
+            e_ia_b2a = (mo_energy[0][viridxa] - mo_energy[1][occidxb,None])
+            e_ia_a2b = (mo_energy[1][viridxb] - mo_energy[0][occidxa,None])
+
+            if self.extype==0:
+                hdiag = np.hstack((e_ia_b2a.ravel(), -e_ia_a2b.ravel()))
+            elif self.extype==1:
+                hdiag = np.hstack((e_ia_a2b.ravel(), -e_ia_b2a.ravel()))
+
+        vresp = gen_uhf_response_sf(
+            mf,
+            hermi=0,
+            collinear=self.collinear,
+            collinear_samples=self.collinear_samples,
+        )
+
+        def vind(zs):
+            nz = len(zs)
+            zs = np.asarray(zs).reshape(nz,-1)
+            if self.extype==0:
+                zs_b2a = zs[:, :noccb*nvira].reshape(nz, noccb, nvira)
+                zs_a2b = zs[:, noccb*nvira:].reshape(nz, nocca, nvirb)
+                dm_b2a = lib.einsum('xov,pv,qo->xpq', zs_b2a, orbva, orbob.conj())
+                dm_a2b = lib.einsum('xov,qv,po->xpq', zs_a2b, orbvb.conj(), orboa)
+            elif self.extype==1:
+                zs_a2b = zs[:, :nocca*nvirb].reshape(nz, nocca, nvirb)
+                zs_b2a = zs[:, nocca*nvirb:].reshape(nz, noccb, nvira)
+                dm_a2b = lib.einsum('xov,pv,qo->xpq', zs_a2b, orbvb, orboa.conj())
+                dm_b2a = lib.einsum('xov,qv,po->xpq', zs_b2a, orbva.conj(), orbob)
+            dms = dm_b2a + dm_a2b
+
+            v1ao = vresp(dms)
+            if self.extype==0:
+                v1_top = lib.einsum('xpq,qo,pv->xov', v1ao, orbob, orbva.conj())
+                v1_bot = lib.einsum('xpq,po,qv->xov', v1ao, orboa.conj(), orbvb)
+                if np.allclose(mo_coeff[0], mo_coeff[1]):
+                    v1_top += lib.einsum('ab,xib->xia', fockva, zs_b2a)
+                    v1_top -= lib.einsum('ji,xja->xia', fockob, zs_b2a)
+                    v1_bot += lib.einsum('ab,xib->xia', fockvb, zs_a2b)
+                    v1_bot -= lib.einsum('ji,xja->xia', fockoa, zs_a2b)
+                else:
+                    v1_top += zs_b2a * e_ia_b2a
+                    v1_bot += zs_a2b * e_ia_a2b
+            elif self.extype==1:
+                v1_top = lib.einsum('xpq,qo,pv->xov', v1ao, orboa, orbvb.conj())
+                v1_bot = lib.einsum('xpq,po,qv->xov', v1ao, orbob.conj(), orbva)
+                if np.allclose(mo_coeff[0], mo_coeff[1]):
+                    v1_top += lib.einsum('ab,xib->xia', fockvb, zs_a2b)
+                    v1_top -= lib.einsum('ji,xja->xia', fockoa, zs_a2b)
+                    v1_bot += lib.einsum('ab,xib->xia', fockva, zs_b2a)
+                    v1_bot -= lib.einsum('ji,xja->xia', fockob, zs_b2a)
+                else:
+                    v1_top += zs_a2b * e_ia_a2b
+                    v1_bot += zs_b2a * e_ia_b2a
+            hx = np.hstack((v1_top.reshape(nz, -1), -v1_bot.reshape(nz, -1)))
+            return hx
+
+        return vind, hdiag
+
+    def init_guess(self, mf=None, nstates=None):
+        if mf is None:
+            mf = self._scf
+        if nstates is None:
+            nstates = self.nstates
+        nstates += 3
+        x0 = self._init_guess(mf, nstates)
+        nx = len(x0)
+        nmo = mf.mo_occ[0].size
+        nocca, noccb = mf.nelec
+        nvira = nmo - nocca
+        nvirb = nmo - noccb
+        if self.extype == 0:
+            y0 = np.zeros((nx, nocca*nvirb))
+        else:
+            y0 = np.zeros((nx, noccb*nvira))
+        return np.hstack([x0.reshape(nx, -1), y0])
+
+
+    def gen_pickeig(self, extype=1):
+        '''
+        Selects physical roots based on the norm condition ||X|| > ||Y||.
+        This replaces the previous empirical energy threshold (`positive_eig_threshold`).
+        '''
+        mo_occ = self._scf.mo_occ
+        occidxa = np.where(mo_occ[0]>0)[0]
+        occidxb = np.where(mo_occ[1]>0)[0]
+        viridxa = np.where(mo_occ[0]==0)[0]
+        viridxb = np.where(mo_occ[1]==0)[0]
+        nocca = len(occidxa)
+        noccb = len(occidxb)
+        nvira = len(viridxa)
+        nvirb = len(viridxb)
+        if extype==0:
+            ov = noccb * nvira
+        elif extype==1:
+            ov = nocca * nvirb
+        def pickeig(w, v, nroots, envs):
+            xs = np.vstack(envs.get('xs'))
+            ritz_vectors = v.T.dot(xs[:envs.get('space')])
+            x_part = ritz_vectors[:, :ov]
+            y_part = ritz_vectors[:, ov:]
+            norm_x2 = np.linalg.norm(x_part, axis=1)**2
+            norm_y2 = np.linalg.norm(y_part, axis=1)**2
+            is_physical = (norm_x2 > norm_y2 - 1e-4) & (abs(w.imag) < 1e-4)
+            realidx = np.where(is_physical)[0]
+            if len(realidx) < nroots:
+                remaining_idx = np.setdiff1d(np.arange(len(w)), realidx)
+                sorted_rem = remaining_idx[np.argsort(w[remaining_idx].real)]
+                needed = nroots - len(realidx)
+                realidx = np.concatenate([realidx, sorted_rem[:needed]])
+            return lib.linalg_helper._eigs_cmplx2real(w, v, realidx, real_eigenvectors=True)
+        return pickeig
+
+    def kernel(self, x0=None, nstates=None, extype=None):
+        '''
+        Spin-flip TDDFT diagonalization solver
+        '''
+        cpu0 = (logger.process_clock(), logger.perf_counter())
+
+        self.check_sanity()
+        self.dump_flags()
+
+        if extype is None:
+            extype = self.extype
+        else:
+            self.extype = extype
+
+        if nstates is None:
+            nstates = self.nstates
+        else:
+            self.nstates = nstates
+
+        log = logger.Logger(self.stdout, self.verbose)
+
+        vind, hdiag = self.gen_vind()
+        precond = self.get_precond(hdiag)
+
+        if x0 is None:
+            x0 = self.init_guess()
+
+        pickeig = self.gen_pickeig(extype=extype)
+
+        self.converged, self.e, x1 = davidson_nosym1(vind, x0, precond,
+                                            tol=self.conv_tol,
+                                            nroots=nstates,
+                                            max_cycle=self.max_cycle,
+                                            pick=pickeig,
+                                            verbose=log)
+
+        nmo = self._scf.mo_occ[0].size
+        nocca, noccb = self._scf.nelec
+        nvira = nmo - nocca
+        nvirb = nmo - noccb
+
+        if self.extype==0:
+            def norm_xy(z):
+                x = z[:noccb*nvira].reshape(noccb, nvira)
+                y = z[noccb*nvira:].reshape(nocca, nvirb)
+                norm = lib.norm(x)**2 - lib.norm(y)**2
+                norm = np.sqrt(1./norm)
+                return x*norm, y*norm
+        elif self.extype==1:
+            def norm_xy(z):
+                x = z[:nocca*nvirb].reshape(nocca, nvirb)
+                y = z[nocca*nvirb:].reshape(noccb, nvira)
+                norm = lib.norm(x)**2 - lib.norm(y)**2
+                norm = np.sqrt(1./norm)
+                return x*norm, y*norm
+
+        self.xy = [norm_xy(z) for z in x1]
+
+        if self.chkfile:
+            lib.chkfile.save(self.chkfile, 'tddft/e', self.e)
+            lib.chkfile.save(self.chkfile, 'tddft/xy', self.xy)
+
+        log.timer('TDDFT_SF', *cpu0)
+
+        self._finalize()
+        return self.e, self.xy
+
+SFTDA = TDA_SF
+SFTDDFT = TDDFT_SF
+
+dft.uks.UKS.TDA_SF   = lib.class_as_method(TDA_SF)
+dft.uks.UKS.TDDFT_SF = lib.class_as_method(TDDFT_SF)
+scf.uhf.UHF.TDA_SF   = lib.class_as_method(TDA_SF)
+scf.uhf.UHF.TDDFT_SF = lib.class_as_method(TDDFT_SF)
+dft.uks.UKS.SFTDA = lib.class_as_method(TDA_SF)
+dft.uks.UKS.SFTDDFT = lib.class_as_method(TDDFT_SF)
+scf.uhf.UHF.SFTDA = lib.class_as_method(TDA_SF)
+scf.uhf.UHF.SFTDDFT = lib.class_as_method(TDDFT_SF)


### PR DESCRIPTION
Adds the first working implementation of NEST.

- **`nest.sftda`**: Spin-flip TDA/TDDFT (SF-TDA/SF-TDDFT) on UKS/ROKS references,
  supporting collinear and multicollinear XC kernels.
- **`nest.nttda`**: Noncollinear Tensor TDA (NT-TDA) on ROKS references,
  covering ΔS = 0, ±1 excitations with no spin contamination.
- **`nest.grad`**: Analytic nuclear gradients for SF-TDA/TDDFT on UKS references.
- **`examples/`**: Runnable scripts for all three modules.
- **`pyproject.toml`**: Build system and `[dev]` extras (pytest, ruff).
- **`.github/workflows/ci.yml`**: Lint (ruff) + test (pytest) on push/PR.